### PR TITLE
docs(data-structure): 新增条目/音乐/漫画/小说数据结构详解文档(含流程图)

### DIFF
--- a/docs/data-structure/README.md
+++ b/docs/data-structure/README.md
@@ -1,0 +1,181 @@
+# 内容数据结构文档（总览）
+
+> 本文档族描述 Ikaros 核心内容数据模型：**条目（Subject）**、**剧集（Episode）** 与 **附件（Attachment）** 的三层结构，以及音乐、漫画、小说四类内容如何复用同一套模型。
+>
+> - 文档语言：中文
+> - 适用范围：`api` / `server` 模块的数据层、`console` 前端数据消费
+> - 代码基准：`main` 分支（本文档族编写时的最新提交）
+
+## 目录
+
+| 文档 | 内容 |
+|------|------|
+| [README.md](./README.md) | 总览、统一模型设计、全局 ER 图（本文档） |
+| [subject.md](./subject.md) | 条目（Subject）数据结构详解：表、字段、枚举、约束、DTO/VO |
+| [music.md](./music.md) | 音乐数据结构：专辑/歌曲如何映射到 Subject/Episode |
+| [comic.md](./comic.md) | 漫画数据结构：卷/话/页与图片附件的绑定关系 |
+| [novel.md](./novel.md) | 小说数据结构：章节与文本附件的绑定关系 |
+
+## 一、核心设计思想
+
+Ikaros 的内容数据采用 **“一种条目、二级剧集、通用附件”** 的统一模型，而不是为每种媒体类型分别建表：
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                      Subject（条目）                      │
+│   type 区分：ANIME / COMIC / GAME / MUSIC / NOVEL / ...   │
+└──────────────────────────┬───────────────────────────────┘
+                           │ 1 : N
+┌──────────────────────────▼───────────────────────────────┐
+│                      Episode（剧集/章节）                 │
+│   动画 → 集；音乐 → 歌曲；漫画 → 话；小说 → 章节          │
+│   group 区分：MAIN / OP / ED / OST / ...                 │
+└──────────────────────────┬───────────────────────────────┘
+                           │ M : N（attachment_reference）
+┌──────────────────────────▼───────────────────────────────┐
+│                    Attachment（附件/文件）                │
+│   图片 / 视频 / 音频 / 文本，由 AttachmentDriver 提供     │
+└──────────────────────────────────────────────────────────┘
+```
+
+四类内容的具体映射：
+
+| 内容类型 | 条目 | 剧集 | 附件绑定 | 前端绑定方式 |
+|----------|------|------|----------|--------------|
+| 动画 ANIME | Subject | 集（`MAIN` 正片 / OP / ED / SP…） | 每集 1 个视频文件（可选字幕） | 单资源选择 |
+| 音乐 MUSIC | Subject（专辑） | 歌曲（`MAIN`，`sequence` 为曲序） | 每首歌 1 个音频（可多资源：音频+歌词） | 多资源选择 |
+| 漫画 COMIC | Subject | 话/卷（`MAIN`，`sequence` 为话序） | 每话多张页面图片（按附件 ID 排序） | 多资源选择 |
+| 小说 NOVEL | Subject | 章节（`MAIN`，`sequence` 为章序） | 每章 1 个文本文件 | 单资源选择 |
+
+> 判定依据：`console/src/modules/content/subject/SubjectDetails.vue`
+> `initEpisodeHasMultiResource()` —— ANIME / GAME / NOVEL 为单资源，其余类型（COMIC / MUSIC 等）为多资源。
+
+## 二、核心表清单
+
+数据持久化全部位于 PostgreSQL，迁移脚本在 `server/src/main/resources/db/migration/`（Flyway，`V2026xxxxxx__*.sql`）。
+
+| 表 | 作用 | 迁移脚本 |
+|----|------|----------|
+| `subject` | 条目主表 | `V202601101934__DDL_SUBJECT.sql` |
+| `episode` | 剧集/歌曲/话/章节 | `V202601101923__DDL_EPISODE.sql` |
+| `attachment` | 附件（文件） | `V202601101915__DDL_ATTACHMENT.sql` |
+| `attachment_driver` | 附件驱动（本地/WebDAV/自定义） | `V202601101916__DDL_ATTACHMENT_DRIVER.sql` |
+| `attachment_reference` | 附件 ↔ 条目/剧集 绑定 | `V202601101917__DDL_ATTACHMENT_REFERENCE.sql` |
+| `attachment_relation` | 附件间关系（如视频↔字幕） | `V202601101918__DDL_ATTACHMENT_RELATION.sql` |
+| `subject_collection` | 用户条目收藏（在看/看过…） | `V202601101936__DDL_SUBJECT_COLLECTION.sql` |
+| `episode_collection` | 用户剧集进度（看完/进度） | `V202601101924__DDL_EPISODE_COLLECTION.sql` |
+| `subject_relation` | 条目间关系（前传/续集/OST…） | `V202601112313__DDL_SUBJECT_RELATION.sql` |
+| `subject_sync` | 条目同步信息（bgm.tv/TMDB…） | `V202601101938__DDL_SUBJECT_SYNC.sql` |
+| `subject_person` / `subject_character` | 条目参与人员 / 登场角色 | `V202601101937/935__DDL_*.sql` |
+| `person` / `character` | 人物 / 角色主表 | `V202601101930/920__DDL_*.sql` |
+| `person_character` | 人物 ↔ 角色（配音等） | `V202601101931__DDL_PERSON_CHARACTER.sql` |
+| `tag` | 标签（可打标 Subject/Episode/Attachment） | `V202601101939__DDL_TAG.sql` |
+| `episode_list` 系列 | 自定义剧集列表 | `V202601101925/926/927__DDL_*.sql` |
+| `episode_sequence_regular` | 剧集序号匹配正则（责任链） | `V202605301926__DDL_EPISODE_SEQUENCE_REGULAR.sql` |
+| `custom` / `custom_metadata` | 自定义元数据扩展 | `V202601101921/922__DDL_*.sql` |
+| `task` | 后台任务 | `V202601101940__DDL_TASK.sql` |
+| `ikuser` | 用户 | `V202601101928__DDL_IKUSER.sql` |
+
+## 三、全局 ER 图
+
+```mermaid
+erDiagram
+    SUBJECT ||--o{ EPISODE : "包含"
+    SUBJECT ||--o{ SUBJECT_COLLECTION : "被收藏"
+    SUBJECT ||--o{ SUBJECT_RELATION : "关联(出)"
+    SUBJECT ||--o{ SUBJECT_SYNC : "同步"
+    SUBJECT ||--o{ SUBJECT_PERSON : "参与人员"
+    SUBJECT ||--o{ SUBJECT_CHARACTER : "登场角色"
+    SUBJECT ||--o{ EPISODE_LIST : "自定义列表(经EPISODE_LIST_COLLECTION)"
+    SUBJECT ||--o{ ATTACHMENT_REFERENCE : "绑定附件"
+
+    EPISODE ||--o{ EPISODE_COLLECTION : "观看进度"
+    EPISODE ||--o{ ATTACHMENT_REFERENCE : "绑定附件"
+    EPISODE ||--o{ EPISODE_LIST_EPISODE : "自定义列表项"
+
+    ATTACHMENT ||--o{ ATTACHMENT_REFERENCE : "被引用"
+    ATTACHMENT ||--o{ ATTACHMENT_RELATION : "附件间关系"
+    ATTACHMENT }o--|| ATTACHMENT_DRIVER : "由驱动提供"
+
+    PERSON }o--o{ CHARACTER : "person_character"
+    PERSON }o--o{ SUBJECT : "subject_person"
+    CHARACTER }o--o{ SUBJECT : "subject_character"
+
+    CUSTOM ||--o{ CUSTOM_METADATA : "键值扩展"
+    IKUSER ||--o{ SUBJECT_COLLECTION : "收藏"
+    IKUSER ||--o{ EPISODE_COLLECTION : "进度"
+
+    SUBJECT {
+        uuid id PK "uuidv7"
+        varchar type "SubjectType"
+        varchar name
+        varchar name_cn
+        varchar cover
+        varchar infobox "key:value 逐行"
+        varchar summary
+        boolean nsfw
+        timestamp air_time
+        double score
+    }
+    EPISODE {
+        uuid id PK
+        uuid subject_id FK
+        varchar name
+        varchar name_cn
+        varchar description
+        timestamp air_time
+        varchar ep_group "EpisodeGroup"
+        real sequence
+    }
+    ATTACHMENT {
+        uuid id PK
+        uuid parent_id "目录树父节点"
+        varchar type "File/Directory/Driver_*"
+        varchar url
+        varchar path
+        varchar fs_path
+        varchar name
+        bigint size
+        boolean deleted
+        uuid driver_id
+        varchar sha1
+    }
+    ATTACHMENT_REFERENCE {
+        uuid id PK
+        varchar type "SUBJECT/EPISODE/USER_AVATAR"
+        uuid attachment_id
+        uuid reference_id
+    }
+```
+
+## 四、关键约束汇总
+
+1. **主键均为 `uuid`，默认 `uuidv7()`**（时间有序，可用作自然排序）。
+2. 大多数业务实体继承 `BaseEntity` 审计字段：`create_time`、`create_uid`、`delete_status`、`update_time`、`update_uid`、`ol_version`（乐观锁版本）。
+   > 例外：`attachment`（附件）表**不继承审计字段**，仅含 `update_time`（见 `AttachmentEntity` 与 `V202601101915__DDL_ATTACHMENT.sql`）。`V202608220000__DDL_ATTACHMENT_UNIQUE_TYPE_PARENT_NAME.sql` 为其新增 `(type, parent_id, name)` 唯一约束，防止并发刷新目录重复插入。
+3. **`episode` 唯一约束**：`UNIQUE (subject_id, ep_group, sequence, name)` —— 同一条目内，分组 + 序号 + 名称组合不可重复。
+4. **`subject_sync` 唯一约束**：`UNIQUE (platform, platform_id)` —— 同一平台的外部 ID 只能对应一个条目。
+5. **`custom` 唯一约束**：`(c_group, version, kind, name)`。
+6. **`attachment_reference`**：`(type, attachment_id, reference_id)` 三元组表达“哪个附件绑定到哪个实体”；类型为 `EPISODE` 时即“剧集资源”。
+7. 附件由目录树组织：`attachment.parent_id` 指向父目录附件，顶层目录是 `attachment` 虚拟根（`AttachmentConst.V_ROOT_DIRECTORY_PARENT_ID`）。
+
+## 五、聚合视图（API 层组合）
+
+- `EpisodeRecord(episode, List<EpisodeResource>)`：剧集 + 其附件资源（`EpisodeResource` 含 `attachmentId / parentAttachmentId / url / canRead / name / tags(如 1080p)`）。
+- `SubjectRecord(subject, List<EpisodeRecord>, List<Tag>, List<SubjectSync>, Map<String,String> extra)`：条目的完整聚合（详情页一次性加载，降低并发请求数）。
+- 资源查询 SQL（`DefaultEpisodeService#findResourcesById`）：
+  `ATTACHMENT_REFERENCE ar, ATTACHMENT att WHERE ar.TYPE='EPISODE' AND ar.REFERENCE_ID=:episodeId AND ar.ATTACHMENT_ID=att.ID ORDER BY ar.TYPE, ar.ATTACHMENT_ID`
+  —— 该查询 TYPE 恒为 `EPISODE`，实际排序键即 **附件 ID（uuidv7 时间序）**：多资源（漫画页、字幕）的“绑定顺序≈上传/导入顺序”。
+
+## 六、相关代码位置
+
+| 主题 | 位置 |
+|------|------|
+| 实体类 | `server/src/main/java/run/ikaros/server/store/entity/*.java` |
+| API 模型 | `api/src/main/java/run/ikaros/api/core/subject/{Subject,Episode,EpisodeRecord,EpisodeResource,SubjectRecord}.java` |
+| 枚举 | `api/src/main/java/run/ikaros/api/store/enums/*.java` |
+| 条目服务 | `server/src/main/java/run/ikaros/server/core/subject/service/` |
+| 剧集服务 | `server/src/main/java/run/ikaros/server/core/episode/` |
+| 音乐服务 | `server/src/main/java/run/ikaros/server/core/music/` |
+| 附件服务 | `server/src/main/java/run/ikaros/server/core/attachment/` |
+| 数据库迁移 | `server/src/main/resources/db/migration/` |

--- a/docs/data-structure/comic.md
+++ b/docs/data-structure/comic.md
@@ -1,0 +1,108 @@
+# 漫画数据结构详解
+
+> 说明：Ikaros 用统一的 `Subject`(`type=COMIC`) + `Episode` + `Attachment` 承载漫画数据。
+> 本文档描述漫画的**卷/话/页**三级结构组成、绑定规则与阅读数据流。
+
+## 一、数据组成（映射关系）
+
+```mermaid
+flowchart LR
+    subgraph Subject["Subject（漫画）type=COMIC"]
+        S1[id]
+        S2[name 漫画名]\nS3[nameCn 中文名]
+        S4[cover 封面]
+        S5[infobox 作者/连载杂志/话数…]
+        S6[summary 简介]
+        S7[airTime 连载开始]\nS8[score]
+    end
+    subgraph Ep["Episode（话/卷）"]
+        E1[id + subjectId]
+        E2[name 第N话 / 第N卷]
+        E3[sequence 话序号]
+        E4[group MAIN]
+        E5[description 话简介]
+    end
+    subgraph Pages["Attachment（页面图片 ×N）"]
+        P1[parentId 指向话/卷目录附件]\nP2[name 001.jpg … 020.jpg]
+        P3[url / path / fsPath]
+        P4[size + sha1]
+        P5[driverId 驱动]
+    end
+    Subject -- "1:N" --> Ep
+    Ep -- "M:N（attachment_reference type=EPISODE）" --> Pages
+```
+
+### 1.1 卷 / 话建模约定
+
+| 漫画语义 | 落点 | 约定 |
+|----------|------|------|
+| 漫画本体 | `Subject(type=COMIC)` | `name`/`nameCn`/`cover`/`summary`/`airTime`；`infobox` 记作者、连载杂志、单行本数等 |
+| 单话（章） | `Episode(group=MAIN)` | `name`=“第 N 话”或卷内标题，`sequence`=话序（1 起递增），`description` 可存话简介 |
+| 单行本卷 | 可选：用 `Episode(group=MAIN, sequence=卷序)` | 若按卷组织，则卷为 Episode，页直接绑卷；也可“卷内再分话”（用 `sequence` 区间或 `name` 前缀区分） |
+| 页面图片 | `Attachment(File/Driver_File)` | 每页一张图；按绑定顺序 = 阅读顺序（attachment_reference 按 `attachment_id` uuidv7 排序） |
+| 封面 | `Subject.cover` 或 `AttachmentReference(type=SUBJECT)` | 条目封面（后者可让封面对应驱动内真实文件） |
+
+> 前端多资源判定：`SubjectDetails.vue#initEpisodeHasMultiResource` 中 COMIC **不**在单资源名单内，
+> 因此每话可绑定多张页面图（多资源选择器）。
+
+## 二、结构要求
+
+1. **`subject.type` 必须为 `COMIC`**；`name` 必填，`nsfw` 必填。
+2. **话（Episode）序号**：同一漫画内 `(ep_group=MAIN, sequence, name)` 唯一（episode 表约束）；
+   话序号应连续递增（1,2,3…），支持 `sequence` 为小数（番外 1.5 等）。
+3. **页序约定**：页面图片通过 `attachment_reference(type=EPISODE, reference_id=话id)` 绑定；
+   **阅读顺序 = attachment_reference.attachment_id 升序**（uuidv7 时间有序），
+   因此导入时应按页名自然排序（001.jpg→020.jpg）批量绑定。
+4. **单话多图**：一话至少 1 张图；建议把整话图片的父目录附件设为话的目录
+   （`attachment.parent_id` → 话目录附件），便于整目录导入。
+5. **封面**：建议 `AttachmentReference(type=SUBJECT)` 绑定封面附件（有监听器自动回写 `subject.cover`）。
+6. **删除级联**：删除漫画 → 删其全部话 → 解绑附件引用（附件本体保留，由附件模块管理）。
+
+## 三、阅读数据流
+
+```mermaid
+sequenceDiagram
+    participant C as 前端阅读器\n(console)
+    participant R as SubjectDetails\n/EpisodeDetail
+    participant E as EpisodeService
+    participant A as AttachmentEndpoint
+    participant D as 附件驱动\n(本地/S3/WebDAV)
+
+    C->>E: GET /episode/records/subjectId/{漫画id}\n(取全部话 + 资源)
+    E-->>C: 话列表（每话 N 个 EpisodeResource）
+    C->>E: GET /episode/{话id} 或直接用 resources
+    E-->>C: EpisodeResource[页面1..N](attachmentId, url)
+    loop 逐页渲染
+        C->>A: GET /attachment/stream/id/{attachmentId}\n?redirect=true
+        alt 驱动提供直链（S3 预签名/自定义域）
+            A-->>C: 307 → 直链\nC->>D: 获取图片字节
+        else 本地/不可直链
+            A-->>C: 200 图片流（Content-Type 按扩展名）\nC->>A: 下载字节解码
+        end
+        C->>C: 按资源顺序拼接“页”并翻页
+    end
+```
+
+- 翻页顺序直接依赖 `EpisodeResource` 列表顺序（= 附件 ID 升序）。
+- 图片类型支持：`FileType.IMAGE`（jpg/png/webp/gif…）；附件流接口按扩展名返回 `Content-Type`。
+- 漫画无音轨，不需要 `attachment_relation(VIDEO_SUBTITLE)`。
+
+## 四、相关 API 与代码
+
+| 用途 | API | 代码位置 |
+|------|-----|----------|
+| 漫画列表/详情 | `GET /subjects/condition?type=COMIC`、`GET /subject/{id}` | `SubjectEndpoint` |
+| 话列表（含资源） | `GET /episode/records/subjectId/{id}` | `EpisodeEndpoint` / `DefaultEpisodeService#findRecordsBySubjectId`（聚合 EpisodeRecord） |
+| 话 CRUD | `POST/PUT/DELETE /episode...` | `EpisodeEndpoint` |
+| 页流 | `GET /attachment/stream/id/{attachmentId}?redirect=true` | `AttachmentEndpoint#getStreamById`（307 直链 / 代理流） |
+| 附件绑定 | `attachment_reference` | `AttachmentServiceImpl` / `DefaultEpisodeService#findResourcesById` |
+
+## 五、扩展：卷内分话推荐组织
+
+若漫画单行本卷数多、每卷内又有独立话目，推荐：
+
+- `Episode(group=MAIN, sequence=卷序, name=“第N卷”)` 为卷级容器；
+- 卷级容器内不直接绑图，而是卷的**页面**用 `sequence=卷序.话内序号`（如 1.1、1.2…）表达“第 1 卷第 1 页”，
+  或每话一个 Episode 并依赖 `attachment.parent_id` 目录结构保持卷内层级。
+
+> 该细则不作为强制约束——只要 `episode` 唯一约束与页序约定满足，模型即自洽。

--- a/docs/data-structure/music.md
+++ b/docs/data-structure/music.md
@@ -1,0 +1,147 @@
+# 音乐数据结构详解
+
+> 说明：Ikaros **没有独立的音乐表**——音乐专辑（Album）复用 `Subject`（`type=MUSIC`），
+> 歌曲（Song）复用 `Episode`，音频文件复用 `Attachment` 并通过 `attachment_reference` 绑定。
+> 本文档描述这一映射、字段组成与结构要求、以及播放流程。
+
+## 一、数据组成（映射关系）
+
+```mermaid
+flowchart LR
+    subgraph Subject["Subject（专辑）type=MUSIC"]
+        S1[id]
+        S2[name 专辑名]
+        S3[nameCn 中文名]
+        S4[cover 封面]
+        S5[summary 专辑简介]
+        S6[airTime 发行时间]
+        S7[score 评分 0-10]
+        S8[nsfw]
+    end
+    subgraph Episode["Episode（歌曲）"]
+        E1[id]
+        E2[subjectId 所属专辑]
+        E3[name 曲名]
+        E4[nameCn 中文名]
+        E5[sequence 曲序/碟序]
+        E6[group MAIN / MUSIC_DIST1-5]
+        E7[description 歌词/简介]
+    end
+    subgraph Att["Attachment（音频文件）"]
+        A1[id]
+        A2[name xxx.flac]
+        A3[url / path / fsPath]
+        A4[size]
+        A5[driverId 驱动]
+    end
+    Subject -- "1:N（episode.subject_id）" --> Episode
+    Episode -- "M:N（attachment_reference type=EPISODE）" --> Att
+```
+
+### 1.1 专辑 → Subject 字段映射
+
+| 音乐语义 | Subject 字段 | 必填 | 说明 |
+|----------|--------------|------|------|
+| 专辑 ID | `id` | 自动 | uuidv7 |
+| 专辑名 | `name` | ✅ | 原始名称 |
+| 中文名 | `nameCn` | — | |
+| 封面 | `cover` | — | URL 或附件流地址 |
+| 简介 | `summary` | — | 专辑描述 |
+| 发行时间 | `airTime` | — | 专辑发售日 |
+| 评分 | `score` | — | 0–10 |
+| NSFW | `nsfw` | ✅ | |
+| 类型 | `type` | ✅ | **固定 `MUSIC`**（创建/更新时由服务强制设置） |
+
+> 服务端强制：`DefaultMusicService#createAlbum/updateAlbum` 会 `subject.setType(MUSIC)`，
+> 即使客户端传错类型也会被纠正；查询侧 `findAlbumById` 会 `filter(type == MUSIC)`。
+
+### 1.2 歌曲 → Episode 字段映射
+
+| 音乐语义 | Episode 字段 | 必填 | 说明 |
+|----------|--------------|------|------|
+| 歌曲 ID | `id` | 自动 | |
+| 所属专辑 | `subjectId` | ✅ | 由 `music/album/{id}/songs` 列表自动回填 |
+| 曲名 | `name` | ✅ | |
+| 中文名 | `nameCn` | — | |
+| 简介/歌词 | `description` | — | |
+| 发行时间 | `airTime` | — | |
+| 曲序 | `sequence` | — | 单碟时 1..N；多碟可用 `MUSIC_DIST1..5` 分组 |
+| 分组 | `group` | — | `MAIN`（默认）或 `MUSIC_DIST1`~`MUSIC_DIST5`（碟片 1~5） |
+
+### 1.3 歌曲文件 → Attachment / attachment_reference
+
+- 每个音频文件是一个 `Attachment`（`type=File` 或 `Driver_File`，由 `AttachmentDriver` 提供）。
+- 通过 `attachment_reference(type=EPISODE, attachment_id=音频, reference_id=歌曲 episodeId)` 绑定。
+- 一首歌可绑定 **多个资源**（前端针对 MUSIC 开启多资源选择）：音频 + 歌词（lrc）、封面图等；
+  排序依据 `attachment_reference.attachment_id`（uuidv7 时间序）即“先绑定的在前”。
+
+## 二、数据模型（DTO）
+
+| DTO | 字段 | 说明 |
+|-----|------|------|
+| `Music`（`api/.../core/music/Music.java`） | `id/name/nameCn/cover/description/airTime/score/rank/nsfw/songCount` | 专辑视图；`songCount` 由 `episodeService.countBySubjectId` 实时计算 |
+| `Song`（`api/.../core/music/Song.java`） | `id/subjectId/name/nameCn/description/airTime/sequence/group` | 歌曲视图；与 `Episode` 一一对应 |
+
+## 三、结构要求
+
+1. **`subject.type` 必须为 `MUSIC`**（服务层强制）。
+2. **歌曲 `name` 非空**；同一专辑内 `(ep_group, sequence, name)` 不可重复（`episode` 唯一约束）。
+3. **专辑必须显式关联歌曲**：歌曲 `subjectId` 指向专辑；删除专辑时 cascade 清理其歌曲与附件引用。
+4. **歌曲必须绑定音频附件** 才能播放；绑定关系写入 `attachment_reference(type=EPISODE)`。
+5. 每首歌建议 `sequence` 递增（播放列表排序），跨碟用 `MUSIC_DIST{n}` 分组 + 碟内序号。
+6. 歌词文件建议以 `attachment_reference` 绑定到同一歌曲（多资源），不单独建模。
+
+## 四、API（前缀 `/api`，`MusicEndpoint`）
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/music/albums/{page}/{size}` | 专辑分页列表 |
+| GET | `/music/album/{id}` | 专辑详情（含实时 `songCount`） |
+| POST | `/music/album` | 创建专辑（强制 type=MUSIC） |
+| PUT | `/music/album` | 更新专辑 |
+| DELETE | `/music/album/{id}` | 删除专辑（级联） |
+| GET | `/music/album/{id}/songs` | 专辑歌曲列表 |
+| POST | `/music/song` | 新增歌曲 |
+| PUT | `/music/song` | 更新歌曲 |
+| DELETE | `/music/song/{id}` | 删除歌曲 |
+| GET | `/music/search/{keyword}/{page}/{size}` | 专辑搜索（名称 Base64 模糊） |
+
+## 五、播放流程（数据流）
+
+```mermaid
+sequenceDiagram
+    participant C as 前端(console)
+    participant M as MusicEndpoint
+    participant E as EpisodeService
+    participant A as AttachmentEndpoint
+    participant S as S3/对象存储直链
+
+    C->>M: GET /music/album/{id}/songs
+    M->>E: findAllBySubjectId(id)
+    E-->>M: Flux<Episode>(歌曲)
+    C->>E: GET /episode/records/subjectId/{id}
+    E-->>C: EpisodeRecord(歌曲 + EpisodeResource[音频附件])
+    C->>A: GET /attachment/stream/id/{attachmentId}?redirect=true
+    A-->>A: getReadUrl → 外部直链(S3 预签名/自定义域) ?
+    alt 外部直链
+        A-->>C: 307 Temporary Redirect (Location=直链)
+        C->>S: GET 直链（307 保留 Range/方法，可拖动）
+    else 本地/代理
+        A-->>C: 200 二进制流（带 Range 支持 206）
+    end
+```
+
+- 播放源统一走 `/attachment/stream`，音乐与动画/漫画共用同一条流链路；
+  外部直链场景返回 **307**（保留 GET 与 Range，播放器可拖动进度条；相关改动见 `PR #870`）。
+- Subsonic 兼容层（`DefaultSubsonicService`）也复用 `episodeService.findResourcesById`
+  提供音乐流媒体服务，数据源完全相同。
+
+## 六、代码位置
+
+| 主题 | 位置 |
+|------|------|
+| 音乐服务 | `server/.../core/music/service/impl/DefaultMusicService.java` |
+| 音乐端点 | `server/.../core/music/endpoint/MusicEndpoint.java` |
+| 专辑 DTO | `api/.../core/music/Music.java`、`Song.java` |
+| 歌曲资源 | `api/.../core/subject/EpisodeRecord.java`、`EpisodeResource.java` |
+| DB | `subject`、`episode`、`attachment_reference`（见 subject.md / README） |

--- a/docs/data-structure/novel.md
+++ b/docs/data-structure/novel.md
@@ -1,0 +1,104 @@
+# 小说数据结构详解
+
+> 说明：Ikaros 用统一的 `Subject`(`type=NOVEL`) + `Episode` + `Attachment` 承载小说数据。
+> 本文档描述小说的**章节**与**文本文件**绑定规则、结构要求及阅读数据流。
+
+## 一、数据组成（映射关系）
+
+```mermaid
+flowchart LR
+    subgraph Subject["Subject（小说）type=NOVEL"]
+        S1[id]
+        S2[name 书名]
+        S3[nameCn 中文名]
+        S4[cover 封面]
+        S5[infobox 作者/出版社/连载状态…]
+        S6[summary 简介]
+        S7[airTime 出版时间]
+        S8[score 评分]
+    end
+    subgraph Ep["Episode（章节）"]
+        E1[id + subjectId]
+        E2[name 第一章 / 序章 / 第N话]
+        E3[sequence 章序]
+        E4[group MAIN]
+        E5[description 章节简介/预告]
+    end
+    subgraph Txt["Attachment（文本文件）"]
+        T1[id]
+        T2[name chapter01.txt / .epub]
+        T3[url / path / fsPath]
+        T4[size]
+        T5[driverId 驱动]
+    end
+    Subject -- "1:N" --> Ep
+    Ep -- "1:1（attachment_reference type=EPISODE）" --> Txt
+```
+
+### 1.1 章节建模约定
+
+| 小说语义 | 落点 | 约定 |
+|----------|------|------|
+| 小说本体 | `Subject(type=NOVEL)` | `name`/`nameCn`/`cover`/`summary`/`airTime`；`infobox` 记作者、出版社、连载状态等 |
+| 章节 | `Episode(group=MAIN)` | `name`=章节标题，`sequence`=章序（1 起递增），`description` 可存章节摘要 |
+| 章节正文 | `Attachment(File/Driver_File)` | 每章一个文本文件（txt / epub / markdown） |
+
+> **单资源约束**：前端 `SubjectDetails.vue#initEpisodeHasMultiResource` 中 NOVEL 在单资源名单内，
+> 即每章**只允许绑定 1 个文本附件**，界面用单选附件对话框。
+
+## 二、结构要求
+
+1. **`subject.type` 必须为 `NOVEL`**；`name` 必填、`nsfw` 必填。
+2. **章节（Episode）**：同一小说内 `(ep_group=MAIN, sequence, name)` 唯一；
+   章序建议连续递增（可含 0.x 番外、插曲）。
+3. **每章绑定 1 个文本附件**（`attachment_reference(type=EPISODE, reference_id=章id)`）；
+   绑定时应保证 `AttachmentType` 为文件类（`File` / `Driver_File`）。
+4. **正文格式**：优先 `txt`（UTF-8）；`epub` 亦可绑定（前端/客户端负责解包渲染），
+   但**单章单附件**前提下建议正文按章拆分为独立 txt，保持与章节 1:1。
+5. **封面**：建议 `AttachmentReference(type=SUBJECT)` 绑定封面（自动回写 `subject.cover`）。
+6. **删除级联**：删除小说 → 删全部章节 → 解绑附件引用。
+
+## 三、阅读数据流
+
+```mermaid
+sequenceDiagram
+    participant C as 前端阅读器(console)
+    participant E as EpisodeService
+    participant A as AttachmentEndpoint
+    participant D as 附件驱动(本地/S3/WebDAV)
+
+    C->>E: GET /episode/records/subjectId/{小说id}
+    E-->>C: 章节列表（每章 1 个 EpisodeResource → 文本附件）
+    C->>A: GET /attachment/stream/id/{attachmentId}?redirect=true
+    alt 外部直链（S3 预签名/自定义域）
+        A-->>C: 307 → 直链
+        C->>D: 拉取文本字节
+    else 本地/代理
+        A-->>C: 200 文本流（Content-Type 按扩展名 text/plain）
+    end
+    C->>C: 解码文本 → 分页渲染章节正文
+```
+
+- 正文渲染由前端按需分页；服务端不预渲染。
+- 若章节文件为 `.epub`（压缩容器），客户端负责解包；服务端仅提供字节流。
+- 超长章节：可借助附件流 Range 分段拉取（若驱动支持按字节范围读取）。
+
+## 四、相关 API 与代码
+
+| 用途 | API | 代码位置 |
+|------|-----|----------|
+| 小说列表/详情 | `GET /subjects/condition?type=NOVEL`、`GET /subject/{id}` | `SubjectEndpoint` |
+| 章节列表（含资源） | `GET /episode/records/subjectId/{id}` | `EpisodeEndpoint` / `DefaultEpisodeService` |
+| 章节 CRUD | `POST/PUT/DELETE /episode...` | `EpisodeEndpoint` |
+| 正文流 | `GET /attachment/stream/id/{attachmentId}?redirect=true` | `AttachmentEndpoint#getStreamById` |
+| 附件绑定 | `attachment_reference(type=EPISODE)` | `AttachmentServiceImpl` / `DefaultEpisodeService#findResourcesById` |
+
+## 五、与音乐/漫画的差异小结
+
+| 维度 | 音乐 MUSIC | 漫画 COMIC | 小说 NOVEL |
+|------|-----------|-----------|-----------|
+| 二级结构 | 歌曲（曲序 `sequence`、碟分组 `MUSIC_DIST1-5`） | 话/卷（话序 `sequence`） | 章节（章序 `sequence`） |
+| Episode 资源数 | 多资源（音频+歌词等，前端多选） | 多资源（每话多页图，前端多选） | **单资源**（每章 1 文本，前端单选） |
+| 资源排序 | `attachment_id` 升序 | `attachment_id` 升序 = 页序 | 单资源无排序问题 |
+| 播放/阅读 | 音频流（可拖动，307/206） | 图片逐页流 | 文本字节流 |
+| 扩展元数据 | `infobox` + `custom_metadata` | `infobox` + `custom_metadata` | `infobox` + `custom_metadata` |

--- a/docs/data-structure/subject.md
+++ b/docs/data-structure/subject.md
@@ -1,0 +1,250 @@
+# 条目（Subject）数据结构详解
+
+> 说明：本文档描述 `subject` 及其关联表的数据组成、字段语义、枚举取值与结构要求。
+> 配套总览见 [README.md](./README.md)。
+
+## 一、概述
+
+条目（Subject）是 Ikaros 内容体系的**核心实体**，用 `type` 字段统一承载动画、漫画、游戏、音乐、小说、现实（真人）与其它内容：
+
+| type（SubjectType） | 含义 | 二级结构（Episode 的用法） |
+|--------------------|------|--------------------------|
+| `ANIME` | 动画 / 番剧 | 集（MAIN 正片、OP、ED、SP、OVA…） |
+| `COMIC` | 漫画 | 话 / 卷（按话创建 Episode） |
+| `GAME` | 游戏 | 关卡 / DLC / 章节 |
+| `MUSIC` | 音乐 | 专辑中的歌曲（一首歌一个 Episode） |
+| `NOVEL` | 小说 | 章节（一章一个 Episode） |
+| `REAL` | 现实（影视、真人剧） | 集 |
+| `OTHER` | 其它 | 自定义 |
+
+## 二、数据组成
+
+### 2.1 `subject` 表（条目主表）
+
+来源：`V202601101934__DDL_SUBJECT.sql`、`SubjectEntity.java`
+
+| 字段 | 类型 | 说明 | 结构要求 |
+|------|------|------|----------|
+| `id` | uuid | 主键，默认 `uuidv7()` | 必填（自动生成） |
+| `create_time` / `create_uid` | timestamp / uuid | 创建审计 | BaseEntity |
+| `delete_status` | boolean | 逻辑删除标记 | BaseEntity |
+| `update_time` / `update_uid` | timestamp / uuid | 更新审计 | BaseEntity |
+| `ol_version` | bigint | 乐观锁版本号 | BaseEntity |
+| `type` | varchar(255) | 条目类型（`SubjectType`） | **必填**，读写均须合法枚举 |
+| `name` | varchar(255) | 原始名称 | **必填**（API 层 `@Schema(requiredMode=REQUIRED)`） |
+| `name_cn` | varchar(255) | 中文名称 | 可选 |
+| `cover` | varchar(10000) | 封面 URL 或附件流地址 | 可选 |
+| `infobox` | varchar(50000) | 信息框，`key: value` 逐行纯文本 | 可选；新增 `custom` 表可作结构化扩展 |
+| `summary` | varchar(50000) | 简介 | 可选 |
+| `nsfw` | boolean | 是否 NSFW（匿名环境下可被搜索屏蔽） | **必填**（API 层 REQUIRED） |
+| `air_time` | timestamp(6) | 发行 / 首播时间 | 可选 |
+| `score` | double precision | 评分，0–10 | 可选 |
+
+> `infobox` 格式约定：每行一个字段 `字段名: 值`。前端解析逻辑见
+> `console/src/modules/content/subject/SubjectDetails.vue`（按 `\n` 分行、按 `:` 切分
+> 成 `Map<key, value>` 展示）。例如：
+>
+> ```
+> 中文名: 某科学的超电磁炮
+> 话数: 24
+> 放送开始: 2009-10-02
+> 导演: 长井龙雪
+> ```
+
+### 2.2 `episode` 表（条目二级结构：集 / 歌曲 / 话 / 章）
+
+来源：`V202601101923__DDL_EPISODE.sql`、`EpisodeEntity.java`
+
+| 字段 | 类型 | 说明 | 结构要求 |
+|------|------|------|----------|
+| `id` | uuid | 主键 `uuidv7()` | 必填（自动生成） |
+| `subject_id` | uuid | 所属条目 | **必填**，外键语义指向 `subject.id` |
+| `name` | varchar(255) | 名称（如“第 12 话”“Track 02”） | **必填**（服务层校验非空） |
+| `name_cn` | varchar(255) | 中文名 | 可选 |
+| `description` | varchar(50000) | 描述 / 歌词简介等 | 可选 |
+| `air_time` | timestamp(6) | 播出 / 发行时间 | 可选 |
+| `ep_group` | varchar(50) | 剧集分组（`EpisodeGroup`） | 可选；默认 `MAIN` 见 `Episode#defaultEpisode` |
+| `sequence` | real | 序号（第几集 / 第几话 / 曲目序号） | 可选；用于排序 |
+| 唯一约束 | — | `UK (subject_id, ep_group, sequence, name)` | **同一条目内**分组+序号+名称不可重复 |
+
+> 服务层在 `updateEpisodesWithSubjectId` 等批量场景会强制把 `subjectId` 回填为当前条目 ID。
+> 序号匹配自动化：`episode_sequence_regular` 表通过责任链模式用正则解析附件文件名，
+> 自动得出 `ep_group` / `sequence`（见 `api/.../EpisodeSequenceRegular*.java`）。
+
+### 2.3 附件绑定（`attachment_reference`）
+
+剧集与附件（视频 / 音频 / 图片 / 文本）的绑定全部通过 `attachment_reference` 表：
+
+| 字段 | 说明 |
+|------|------|
+| `type` | 引用类型：`SUBJECT`（条目级，如封面附件）、`EPISODE`（剧集资源）、`USER_AVATAR` |
+| `attachment_id` | 附件 ID |
+| `reference_id` | 被引用实体 ID（`type=EPISODE` 时为 episode 的 id） |
+
+- 条目封面：既可直接填 `cover` 字段（URL），也可绑附件并监听 `AttachmentSubjectCoverChangeListener` 自动回写。
+- 剧集资源聚合：见 `DefaultEpisodeService#findResourcesById`，按 `ar.ATTACHMENT_ID` 排序返回 `EpisodeResource`。
+
+## 三、关联表（数据组成）
+
+### 3.1 收藏与进度（用户侧）
+
+**`subject_collection`**（用户条目收藏，`V202601101936`）：
+
+| 字段 | 说明 |
+|------|------|
+| `user_id` | 用户 |
+| `subject_id` | 条目 |
+| `type` | `CollectionType`：`WISH` 想看 / `DOING` 在看 / `DONE` 看过 / `SHELVE` 搁置 / `DISCARD` 抛弃 |
+| `main_ep_progress` | bigint，正片观看进度（集数） |
+| `is_private` | 是否私密收藏 |
+| `comment` | varchar(5000)，吐槽/短评 |
+| `score` | bigint，用户打分 |
+
+**`episode_collection`**（用户剧集进度，`V202601101924`）：
+
+| 字段 | 说明 |
+|------|------|
+| `user_id` / `subject_id` / `episode_id` | 用户 / 条目 / 剧集 |
+| `finish` | boolean，是否看完 |
+| `progress` | bigint，播放进度（秒/帧） |
+| `duration` | bigint，总时长 |
+| `update_time` | 最近更新 |
+
+### 3.2 条目关系（`subject_relation`）
+
+| 字段 | 说明 |
+|------|------|
+| `subject_id` | 源条目 |
+| `relation_type` | `SubjectRelationType`（见下） |
+| `relation_subject_id` | 目标条目 |
+
+`SubjectRelationType` 取值：`OTHER / ANIME / COMIC / GAME / MUSIC / NOVEL / REAL`（按类型关联）、
+`BEFORE` 前传、`AFTER` 后传、`SAME_WORLDVIEW` 同世界观、
+`ORIGINAL_SOUND_TRACK`（OST）、`ORIGINAL_VIDEO_ANIMATION`（OVA）、`ORIGINAL_ANIMATION_DISC`（OAD）。
+
+### 3.3 同步信息（`subject_sync`）
+
+| 字段 | 说明 |
+|------|------|
+| `subject_id` | 条目 |
+| `platform` | `SubjectSyncPlatform`：`BGM_TV`(bgm.tv) / `TMDB` / `AniDB` / `TVDB` / `VNDB` / `DOU_BAN`(豆瓣) / `OTHER` |
+| `platform_id` | 外部平台 ID |
+| `sync_time` | 同步时间 |
+
+- 唯一约束 `UK (platform, platform_id)`：同一平台的外部 ID 只能归属一个条目，用于幂等同步。
+- 对应接口：`POST /subjects/sync` 相关端点（`SubjectSynchronizer`）。
+
+### 3.4 人员 / 角色
+
+| 表 | 作用 | 关键字段 |
+|----|------|----------|
+| `person` | 人物（职员/声优/作者…） | `name`、`infobox`、`summary` |
+| `character` | 角色 | `name`、`infobox`、`summary` |
+| `subject_person` | 条目 ↔ 人员 | `subject_id`、`person_id` |
+| `subject_character` | 条目 ↔ 角色 | `subject_id`、`character_id` |
+| `person_character` | 人员 ↔ 角色（出演关系） | `person_id`、`character_id` |
+
+> 音乐/漫画/小说场景下：`person` 可用于“艺术家 / 作者 / 插画师”，
+> `character` 可用于“登场角色”，`subject_person/character` 建立关联。
+
+### 3.5 标签（`tag`）
+
+| 字段 | 说明 |
+|------|------|
+| `type` | `TagType`：`SUBJECT` / `EPISODE` / `ATTACHMENT` |
+| `master_id` | 被标记实体 ID |
+| `name` | 标签名 |
+| `user_id` | 打标用户 |
+| `color` | 颜色 |
+| `create_time` | 创建时间 |
+
+### 3.6 自定义剧集列表（`episode_list` 族）
+
+- `episode_list`：列表本体（`name`、`name_cn`、`cover`、`description`、`nsfw`）。
+- `episode_list_collection`：条目 ↔ 列表归属。
+- `episode_list_episode`：列表 ↔ 剧集编排（用户自建“精选”列表）。
+
+### 3.7 自定义元数据（`custom` / `custom_metadata`）
+
+- `custom`：自定义类型声明，唯一约束 `(c_group, version, kind, name)`。
+- `custom_metadata`：`(custom_id, cm_key, cm_value bytea)`，键值对扩展，
+  唯一约束 `(custom_id, cm_key)` —— 可用于扩展条目字段（如音乐发行厂牌、漫画连载杂志等）。
+
+## 四、结构要求（硬性约束）
+
+1. **`type`、`name`、`nsfw` 为条目必填**（API 层 REQUIRED 校验，见 `Subject.java`）。
+2. **同一 `subject_id` 下 `(ep_group, sequence, name)` 组合唯一**，不允许重复创建剧集。
+3. **`subject_sync` 的 `(platform, platform_id)` 全局唯一**。
+4. **删除为逻辑删除**（`delete_status`），不物理删除行。
+5. **写操作默认带乐观锁**（`ol_version` 自增校验），防止并发覆盖。
+6. 附件绑定必须显式写 `attachment_reference`，类型枚举必须为 `SUBJECT` / `EPISODE` / `USER_AVATAR` 之一。
+
+## 五、API 层模型（DTO / VO）
+
+| 模型 | 组成 | 说明 |
+|------|------|------|
+| `Subject` | 与 subject 表一一对应 | 增删改查载体 |
+| `Episode` | subjectId/name/nameCn/description/airTime/sequence/group | 剧集载体；`defaultEpisode()` 提供默认值 |
+| `EpisodeResource` | attachmentId, parentAttachmentId, episodeId, url, canRead, name, tags(1080p 等) | 剧集拥有的附件资源视图 |
+| `EpisodeRecord` | `(Episode, List<EpisodeResource>)` | 剧集+资源聚合 |
+| `SubjectRecord` | `(Subject, List<EpisodeRecord>, List<Tag>, List<SubjectSync>, Map<String,String> extra)` | 条目完整聚合（详情页数据） |
+| `FindSubjectCondition` | page/size/type/name(Base64)/airTimeDesc… | 条件查询 |
+
+## 六、条目 ER 图
+
+```mermaid
+erDiagram
+    SUBJECT ||--o{ EPISODE : "1:N 条目→剧集"
+    SUBJECT ||--o{ SUBJECT_COLLECTION : "用户收藏"
+    SUBJECT ||--o{ SUBJECT_RELATION : "条目关系"
+    SUBJECT ||--o{ SUBJECT_SYNC : "同步"
+    SUBJECT ||--o{ SUBJECT_PERSON : "人员关联"
+    SUBJECT ||--o{ SUBJECT_CHARACTER : "角色关联"
+    SUBJECT ||--o{ ATTACHMENT_REFERENCE : "SUBJECT 类型绑定"
+    EPISODE ||--o{ EPISODE_COLLECTION : "观看进度"
+    EPISODE ||--o{ ATTACHMENT_REFERENCE : "EPISODE 类型绑定"
+    ATTACHMENT_REFERENCE }o--|| ATTACHMENT : "附件"
+
+    SUBJECT {
+        uuid id PK
+        varchar type "必填"
+        varchar name "必填"
+        varchar name_cn
+        varchar cover
+        varchar infobox "key:value"
+        varchar summary
+        boolean nsfw "必填"
+        timestamp air_time
+        double score "0-10"
+    }
+    EPISODE {
+        uuid id PK
+        uuid subject_id FK "必填"
+        varchar name "必填"
+        varchar ep_group "MAIN等"
+        real sequence
+        varchar description
+        timestamp air_time
+        varchar name_cn
+    }
+```
+
+## 七、相关 API 一览（前缀 `/api`）
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/subjects/{page}/{size}` | 分页列表 |
+| GET | `/subject/{id}` | 条目详情 |
+| GET | `/subjects/condition` | 条件查询（类型/名称模糊/排序） |
+| POST | `/subject` | 创建 |
+| PUT | `/subject` | 更新 |
+| DELETE | `/subject/{id}` | 删除（逻辑） |
+| GET | `/episodes/subjectId/{id}` | 条目下全部剧集 |
+| GET | `/episode/records/subjectId/{id}` | 剧集+资源聚合列表（详情页主数据源） |
+| GET | `/episode/attachment/refs/{id}` | 剧集附件引用 |
+| GET | `/episode/count/total/subjectId/{id}` | 剧集总数 |
+| GET | `/episode/count/matching/subjectId/{id}` | 已绑定附件的剧集数 |
+| POST/PUT/DELETE | `/episode` `/episode/id/{id}` | 剧集增删改 |
+
+> 音乐专辑与歌曲的专用端点（`/music/album/**`、`/music/song/**`）是对上述模型的
+> 薄封装，详见 [music.md](./music.md)。


### PR DESCRIPTION
## 概述

新增 `docs/data-structure/` 文档族，系统梳理 Ikaros 的**统一内容模型**：`Subject(条目) → Episode(剧集/歌曲/话/章节) → Attachment(附件)`，并针对条目、音乐、漫画、小说四类内容分别给出数据组成与结构要求，全部配 Mermaid 图（GitHub 可直接渲染）。

## 文档清单

| 文件 | 内容 |
|------|------|
| `README.md` | 总览：统一模型设计、四类内容映射表、核心表清单、全局 ER 图、关键约束汇总 |
| `subject.md` | 条目结构：`subject`/`episode` 表字段、infobox 约定、收藏/同步/关系/人员/角色/标签等关联表、DTO/VO（SubjectRecord/EpisodeRecord） |
| `music.md` | 音乐：专辑=Subject(MUSIC)、歌曲=Episode 的映射与字段对照、音频附件绑定、播放数据流（含 307 重定向说明） |
| `comic.md` | 漫画：卷/话/页三级结构、页序约定（attachment_reference 按附件 ID 排序）、阅读数据流、卷内分话扩展建议 |
| `novel.md` | 小说：章节=Episode、每章单文本附件约束、阅读数据流、与音乐/漫画的差异表 |

## 要点

- 全部内容基于当前代码与 DB 迁移脚本（`db/migration`）梳理，关键结论标注了代码出处
- 覆盖结构要求：必填字段、唯一约束（episode 的 `(subject_id, ep_group, sequence, name)`、subject_sync 的 `(platform, platform_id)` 等）、前端单/多资源绑定规则（ANIME/GAME/NOVEL 单资源，COMIC/MUSIC 多资源）
- 纯文档变更，不含代码改动