### PR TITLE
docs(v2): add responsive app interaction design

### DIFF
--- a/docs/v2/app-interaction/README.md
+++ b/docs/v2/app-interaction/README.md
@@ -449,3 +449,292 @@ UI 必须使用状态 Chip + 解释文本。例如：
 3. 写明页面目的、入口、布局、组件、字段、状态、交互与响应式变化。
 4. 写明安全边界与离线语义（如果适用）。
 5. 如果页面依赖 V2 设计新增业务能力，应先更新对应 V2 产品 / 子系统文档，不在 UI 文档中偷偷创造新的业务事实。
+
+---
+
+## 14. 文档优先级与冲突处理
+
+`docs/v2/` 下的 Product Requirements Document、System Overview 与各子系统设计文档是 Ikaros V2 业务语义的 **Source of Truth**。
+
+`docs/v2/app-interaction/` 是领域设计到客户端实现之间的 UI / UX 契约层，负责把已经确定的业务能力映射为：
+
+- 用户能够理解的信息架构。
+- 可操作的页面与导航。
+- 明确的组件、字段和状态。
+- 跨尺寸响应式布局。
+- 可由 Flutter 客户端实现的交互流程。
+
+设计层级为：
+
+```text
+V2 PRD / System Overview
+        ↓
+Subsystem / Domain Design
+        ↓
+App Interaction Design
+        ↓
+Flutter Implementation
+```
+
+如果 App 交互设计与上位 V2 领域设计发生冲突，应优先修正交互设计，不得为了 UI 实现便利而改变既有领域模型、权限边界、安全语义或业务事实。
+
+如果交互设计需要一个上位文档尚未定义的新业务能力，应先补充相应 PRD / Subsystem Design，再在本目录中设计对应页面。
+
+---
+
+## 15. Review Focus
+
+本目录及后续相关 PR 的 Review 应优先检查“产品与领域语义是否正确”，而不是只检查 Markdown 格式。
+
+### 15.1 信息架构
+
+重点确认：
+
+- App 一级导航是否符合 V2 产品定位。
+- 子系统分组是否符合用户使用路径。
+- 高频功能是否拥有足够短的操作路径。
+- 低频能力是否避免挤占主导航。
+- Desktop 与 Mobile 是否共享一致的信息架构，而不是形成两套产品。
+
+### 15.2 App / CMS 边界
+
+重点确认是否存在将后台管理能力错误暴露到普通用户 App 的情况。
+
+App 应关注当前用户自己的：
+
+- 数据与 Resource。
+- 设备与 Session。
+- 通知与 Activity。
+- Download / Offline / Sync 状态。
+- 用户级 Automation / Integration。
+- 分享、Room 与协作行为。
+
+CMS 负责平台级：
+
+- User / Role / Permission。
+- Parameter / Dictionary / Menu。
+- Audit。
+- Scheduled Job。
+- Runtime Metrics / Health / Alert。
+- Storage Provider。
+- Blob 生命周期、GC 与 Retention。
+- 其他平台治理与运维能力。
+
+### 15.3 领域语义
+
+Review 时必须特别关注 UI 是否错误合并 V2 中已经明确区分的概念，例如：
+
+```text
+Resource ≠ Attachment ≠ Blob
+Download ≠ Cache
+Task ≠ Calendar Event
+Scheduled Time ≠ Deadline
+Time Block ≠ Task
+Goal ≠ Task List
+Transfer ≠ Expense + Income
+Login ≠ Secure Vault Unlock
+Account Recovery ≠ Vault Recovery
+AI Suggestion ≠ Business Fact
+Activity ≠ Audit
+Import ≠ Sync
+```
+
+UI 可以简化操作路径，但不能改变这些业务事实。
+
+### 15.4 响应式布局
+
+重点检查 Compact、Medium、Expanded、Large 四种 Size Class 下：
+
+- 主操作是否始终可发现。
+- 页面是否真正重排，而不是简单拉宽或缩小。
+- Desktop 是否有效利用宽屏空间。
+- Mobile 是否避免堆叠过多复杂组件。
+- Detail / Context Pane 是否只在合适宽度出现。
+- Drawer / NavigationRail / Permanent Sidebar 的切换是否合理。
+
+### 15.5 Offline-first
+
+重点检查以下状态是否能够被用户明确理解：
+
+- Local Only。
+- Pending Sync。
+- Syncing。
+- Synced。
+- Conflict。
+- Offline。
+- Downloaded。
+- Cached。
+- Remote Only。
+- Processing。
+- Restoring。
+- Missing。
+- Corrupted。
+
+禁止将离线本地写入伪装成“已同步成功”，禁止将 Cache 表述为用户主动维护的永久 Download，也禁止后台任务只呈现没有语义的无限 Loading。
+
+### 15.6 Secure Domain
+
+Private Notes 与 Password Manager 应重点检查：
+
+- Locked 状态是否泄露 Protected Metadata。
+- App Switcher / Screenshot 是否泄露敏感内容。
+- Clipboard 是否按规则自动清理。
+- Secure Attachment 是否采用安全读取流程。
+- Offline Cache 是否保持加密。
+- 本地 Search Index 是否符合加密要求。
+- Login 与 Vault Unlock 是否明确分离。
+- Account Recovery 与 Cryptographic Recovery 是否明确分离。
+- AI 是否默认无法访问 Secure Domain。
+
+### 15.7 AI
+
+AI 交互必须满足：
+
+```text
+Agent Permission ⊆ Current Principal Permission
+```
+
+并确认：
+
+- AI 不绕过 Capability / Command。
+- AI 不通过客户端设计获得数据库直写语义。
+- 高风险动作必须存在显式用户确认。
+- Tool Call 有明确执行状态与结果。
+- AI 建议与真实业务状态存在可理解的视觉区别。
+- Context 来源可查看。
+- External Model 的隐私边界可理解。
+- AI Memory 与业务事实保持分离。
+
+---
+
+## 16. Non-goals
+
+本目录当前**不负责定义**：
+
+- 最终视觉稿与 Pixel-perfect UI。
+- 品牌视觉规范。
+- Design Token / Color Token / Typography Token / Animation Token。
+- Flutter Widget 的最终技术选型。
+- Flutter 状态管理方案。
+- Router 实现方案。
+- API Contract / DTO。
+- 数据库 Schema。
+- 后端领域模型。
+- CMS Console 页面交互。
+- 各平台原生能力的具体实现代码。
+
+文档中出现的 Material Design 3 / Flutter Widget 名称主要用于表达推荐的 UI 结构，例如：
+
+```text
+NavigationBar
+NavigationRail
+NavigationDrawer
+SearchAnchor
+FilterChip
+SegmentedButton
+ModalBottomSheet
+Dialog
+SnackBar
+```
+
+这些是推荐实现映射，而不是不可替换的技术约束。
+
+真正需要长期保持稳定的是：
+
+- 信息层级。
+- 页面职责。
+- 字段语义。
+- 用户操作路径。
+- 状态变化。
+- 权限边界。
+- 安全边界。
+- 响应式行为。
+
+---
+
+## 17. 命名约定
+
+为了与 V2 领域模型、代码和未来 Flutter Route 保持一致：
+
+- 目录名使用英文。
+- Markdown 文件名使用英文。
+- 文档正文使用中文。
+- 领域实体优先使用 V2 已定义名称。
+- 首次出现的重要英文领域术语可以保留英文。
+- 不为了 UI 文案重新创造第二套领域概念。
+
+优先沿用的领域术语包括但不限于：
+
+```text
+Resource
+Collection
+Attachment
+Activity
+Task
+Project
+Goal
+OKR
+Time Block
+Ledger
+Transaction
+Vault
+Persona
+Automation
+Room
+```
+
+具体面向最终用户展示的中文文案可以在客户端实现阶段继续优化，但不得因此改变领域语义。
+
+---
+
+## 18. 文档演进原则
+
+后续新增或调整 V2 功能时，推荐按照以下顺序演进：
+
+```text
+1. Product Requirement
+        ↓
+2. System / Subsystem / Domain Design
+        ↓
+3. App Interaction Design
+        ↓
+4. Flutter Implementation
+        ↓
+5. Interaction Feedback
+        ↓
+6. Design Document Revision
+```
+
+原则上不采用长期的“先实现页面，再根据代码反推产品设计”流程。
+
+如果开发过程中发现交互文档无法合理实现，应先判断问题属于：
+
+1. 页面交互设计问题。
+2. 领域模型缺少能力。
+3. API 能力不足。
+4. 平台能力缺失。
+5. 客户端技术限制。
+
+然后回到对应设计层解决，而不是在 Flutter 页面内部引入隐式业务规则。
+
+---
+
+## 19. 设计文档定位
+
+Ikaros V2 App 相关文档的职责层级为：
+
+```text
+PRD
+定义“为什么做、做什么”
+
+System / Subsystem Design
+定义“业务世界如何运作，以及系统级约束是什么”
+
+App Interaction Design
+定义“用户如何看到并操作这些能力”
+
+Flutter App
+定义“客户端如何实现这些交互”
+```
+
+因此 `docs/v2/app-interaction/` 应作为 V2 App UI / UX 的长期维护基线，而不是一次性的页面草稿。

--- a/docs/v2/app-interaction/README.md
+++ b/docs/v2/app-interaction/README.md
@@ -1,0 +1,451 @@
+# Ikaros V2 App 页面布局与交互设计
+
+> 本目录定义 Ikaros V2 官方客户端 App 的页面信息架构、界面布局、字段、组件、状态与交互规则。
+>
+> **文件名与目录名使用英文，文档内容使用中文。**
+>
+> 本文档不是对 V1 Flutter App 的翻版，也不是把 CMS 页面缩小后搬到移动端。设计基线来自 `docs/v2/` 下的 V2 PRD 与各子系统设计文档；旧客户端仅可作为历史交互经验参考。
+
+---
+
+## 1. 设计目标
+
+App 面向 Desktop 与 Mobile，暂定 Flutter 技术栈，并统一采用 Material Design 3。
+
+客户端重点承担：
+
+- 统一资源浏览、搜索、收藏与消费。
+- 视频、音乐、漫画、小说、图片等内容体验。
+- 普通笔记、文档、文章的查看与轻量创作。
+- Productivity / Planning 高频使用场景。
+- Personal Finance 的日常记录与查看。
+- Private Notes 与 Password Manager 的安全本地体验。
+- AI Assistant、Persona、用户级 AI 隐私与 Memory 管理。
+- 个人 Analytics / Insights。
+- 分享、Room、评论、通知等用户协作能力。
+- Automation、Import / Sync 的用户级配置与状态查看。
+- Download、Cache、Offline-first 与本地设备能力。
+- 账号、安全、外观、通知、本地存储与客户端设置。
+
+管理员专属的以下能力不进入普通 App 主菜单：
+
+- 用户 / 角色 / 平台权限管理。
+- 平台参数、字典、后台菜单配置。
+- 系统级审计日志。
+- Scheduled Job 管理。
+- 服务健康、运行时指标、系统告警详情。
+- Storage Provider 管理、Blob GC 策略等系统运维页面。
+
+这些能力属于 CMS Console。若某项状态与用户当前操作直接相关，App 只展示必要的只读状态与操作反馈，例如“归档恢复中”“同步失败”“后台任务进度”。
+
+---
+
+## 2. V2 文档映射
+
+| V2 设计来源 | App 设计落点 |
+|---|---|
+| `Product-Requirements-Document.md` | 全局信息架构、Library、Media、Reading、Music、Photo、Document、Game、Search、Activity、Share、Room、Download、Offline |
+| `Productivity-Planning-Subsystem-Design.md` | Today、Inbox、Task、Project、Calendar、Goal、OKR、Habit、Focus、Review |
+| `Personal-Finance-Accounting-Subsystem-Design.md` | 财务首页、账户、交易、预算、周期账、对账、导入 |
+| `Private-Notes-Subsystem-Design.md` | 私密保险库、Notebook、笔记、编辑、版本、冲突、加密导出与恢复 |
+| `Password-Manager-Subsystem-Design.md` | 密码保险库、条目、TOTP、生成器、健康检查、共享与设备解锁 |
+| `AI-Intelligence-Subsystem-Design.md` | AI Assistant、上下文、工具确认、Memory、AI Job、结果来源与反馈 |
+| `AI-Persona-System-Design.md` | Persona 选择、用户覆盖、会话人格切换、场景化表达设置 |
+| `Data-Analytics-Statistics-Subsystem-Design.md` | 个人内容、消费、效率、创作、财务与存储使用洞察 |
+| `Platform-Integration-Automation-Design.md` | 用户 Automation、执行记录、Import / Sync、Activity、跨对象跳转 |
+| `Security-Identity-Authorization-Crypto-Subsystem-Design.md` | 登录、Step-up Verification、会话、安全设置、恢复流程 |
+| `Secure-Data-Foundation-Design.md` | Secure Domain 锁定、解锁、密文缓存、安全预览、导出边界 |
+| `Platform-Administration-Operations-Subsystem-Design.md` | 仅引用通知、用户自己的活跃会话等用户级能力；管理员页面仍留在 CMS |
+
+---
+
+## 3. 全局导航模型
+
+### 3.1 主导航原则
+
+完整菜单按子系统分组，**所有分组初始默认收起**。
+
+用户展开某一组后，同一时间允许多个分组保持展开；提供“全部收起”动作。通过 Deep Link 直接进入子页面时，允许自动展开当前页面所属分组，以便用户理解当前位置。
+
+### 3.2 菜单分组
+
+#### 首页与发现
+
+- 首页
+- 全局搜索
+- 我的活动
+- 通知中心
+
+#### 内容库
+
+- 统一资源库
+- Collection / 标签
+- 视频与影视
+- 漫画与小说
+- 音乐
+- 图片与相册
+- 文章与文档
+- 游戏与数字资料
+
+#### 计划与生活
+
+- Today / Inbox
+- Task / Project
+- Calendar
+- Goal / OKR
+- Habit / Focus / Review
+- 个人财务
+
+#### 私密与安全
+
+- 私密笔记
+- 密码管理
+
+#### AI 与洞察
+
+- AI Assistant
+- Persona
+- AI Memory / Privacy
+- 数据洞察
+
+#### 协作与自动化
+
+- 分享
+- Room
+- Automation
+- Import / Sync
+
+#### 本地与设备
+
+- 我的下载
+- 离线内容
+- 缓存与空间
+
+#### 我的
+
+- 个人资料
+- 安全与会话
+- 通知偏好
+- 外观与可访问性
+- 客户端设置
+- 关于
+
+---
+
+## 4. 响应式布局分级
+
+Flutter 使用 `LayoutBuilder` / `MediaQuery` 基于可用宽度决定布局，而不是判断具体设备型号。
+
+| Size Class | 宽度 | 主要导航 | 内容布局 |
+|---|---:|---|---|
+| Compact | `< 600dp` | Bottom Navigation + Modal Navigation Drawer | 单列；详情页覆盖式进入 |
+| Medium | `600–839dp` | Navigation Rail + Drawer | 1–2 列；列表/详情可选择分栏 |
+| Expanded | `840–1199dp` | Permanent Side Navigation | 主内容 + 可选右侧详情栏 |
+| Large | `>= 1200dp` | Permanent Side Navigation | 主内容最大宽度 + 右侧上下文栏 / 多栏 |
+
+### 4.1 Compact 底部导航
+
+底部只放 5 个最高频入口，不尝试承载全部系统菜单：
+
+1. 首页
+2. 资源库
+3. Today
+4. AI
+5. 我的
+
+完整子系统入口通过左上角菜单按钮打开 `NavigationDrawer`。Drawer 内严格按上文子系统分组，默认收起。
+
+### 4.2 Medium
+
+左侧显示窄 `NavigationRail`：首页、资源库、Today、AI、我的 + 菜单按钮。点击菜单按钮打开分组 Drawer。
+
+### 4.3 Expanded / Large
+
+左侧固定 260–300dp 侧边栏：
+
+- 顶部 Ikaros 标识、当前服务端名称、连接状态。
+- 中部可滚动分组菜单。
+- 底部用户头像、设备离线状态、设置入口。
+
+分组标题行包含：图标、组名、可选未读/异常徽标、展开箭头。
+
+---
+
+## 5. 全局 App Bar
+
+普通一级页面顶部 App Bar 从左到右：
+
+- Compact：菜单按钮 / 返回按钮。
+- 页面标题。
+- 可选上下文副标题，例如当前 Ledger、Vault、Collection。
+- 搜索图标（支持该页面时）。
+- 同步状态 / 离线状态图标（仅状态异常时常驻）。
+- 页面主操作，例如“新增”“更多”。
+
+Desktop Expanded 模式下，App Bar 与内容区对齐，不重复显示侧栏已有的全局菜单按钮。
+
+---
+
+## 6. 全局搜索入口
+
+支持：
+
+- App Bar 搜索按钮。
+- Desktop `Ctrl/Cmd + K`。
+- Mobile 首页搜索框。
+
+搜索结果分区：Resource、Collection、Document、Task、Goal、Finance 可搜索对象、AI Conversation、已解锁 Secure Domain 本地结果。
+
+Private Notes / Password Manager 未解锁时不得泄露实际标题，只显示安全占位，例如“私密笔记中存在匹配结果，解锁后查看”。
+
+---
+
+## 7. 全局状态语义
+
+每个页面必须处理以下状态，禁止只实现“成功 + 无限转圈”。
+
+### 7.1 Loading
+
+- 首屏使用 Skeleton，尽量保持最终布局尺寸。
+- 仅局部刷新时只对局部区域显示进度，不清空整页。
+- 用户提交写操作时主按钮进入 Loading，避免重复提交。
+
+### 7.2 Empty
+
+空状态必须包含：
+
+- 图标或轻量插图。
+- 明确原因。
+- 一个主操作。
+- 必要时一个次操作。
+
+例如“还没有下载内容” + “去资源库”。
+
+### 7.3 Error
+
+错误卡片至少包含：
+
+- 用户可理解的错误标题。
+- 简短原因。
+- 重试按钮。
+- 可选“查看详情”展开技术信息。
+
+### 7.4 Offline
+
+顶部使用非阻断式 Offline Banner：
+
+- 显示“离线”。
+- 说明哪些能力仍可用。
+- 可进入“待同步变更”页。
+
+页面中已缓存 / 已下载数据继续可用。
+
+### 7.5 Permission Denied
+
+不显示空白页。展示：
+
+- 无权限图标。
+- 缺少的能力描述。
+- 可选请求访问 / 返回按钮。
+
+### 7.6 Locked
+
+Private Notes / Password Manager 统一使用 Locked Surface：
+
+- Vault 名称（如果名称本身允许显示）。
+- 锁图标。
+- 解锁方式。
+- 本地缓存状态。
+- 不显示任何解密后的列表内容。
+
+### 7.7 Processing / Restoring
+
+Resource / Attachment 状态可能为：Available、Cached、Remote、Processing、Restoring、Missing、Corrupted。
+
+UI 必须使用状态 Chip + 解释文本。例如：
+
+- `Restoring`：显示恢复进度、预计完成信息（如果服务端提供）、取消按钮（如果可取消）。
+- `Missing`：显示“内容元数据存在，但当前没有可用副本”。
+- `Corrupted`：使用高风险视觉提示，禁止伪装成普通播放失败。
+
+---
+
+## 8. 通用 Resource Card
+
+资源卡片用于 Library、搜索、Collection、推荐等页面。
+
+### 8.1 海报型
+
+字段顺序：
+
+1. 16:9 / 2:3 / 1:1 按资源类型选择的封面。
+2. 左上角可选类型 Chip。
+3. 右上角收藏按钮。
+4. 封面底部可选消费进度条。
+5. 主标题，最多 2 行。
+6. 副标题：年份 / 创作者 / 资源类型的关键字段。
+7. 可用状态：Cached / Remote / Restoring 等，仅非普通 Available 时显示。
+
+### 8.2 列表型
+
+左侧缩略图，中间标题与元信息，右侧状态 / 进度 / 更多菜单。
+
+### 8.3 交互
+
+- 单击 / Tap：进入 Resource Detail。
+- Desktop 右键：快速菜单。
+- Mobile 长按：Bottom Sheet 快速菜单。
+- 快速菜单：收藏、加入 Collection、下载、分享、相关 Task、更多。
+- 不允许长按默认直接执行破坏性操作。
+
+---
+
+## 9. 通用表单规则
+
+- 必填字段以 `*` 与辅助说明表达，不只靠颜色。
+- 保存按钮在内容未修改时 Disabled。
+- 离线可编辑页面保存为本地 Pending Change，并明确显示“待同步”。
+- 高风险动作需要二次确认；极高风险动作还需 Step-up Verification。
+- 删除与“移入回收站”必须区分。
+- 可恢复操作优先提供 Snackbar Undo。
+
+---
+
+## 10. Flutter 组件映射建议
+
+| 交互语义 | Flutter / Material 3 建议 |
+|---|---|
+| App Shell | `Scaffold` / 自适应 Shell |
+| 底部导航 | `NavigationBar` |
+| 中宽导航 | `NavigationRail` |
+| 完整菜单 | `NavigationDrawer` + 自定义可折叠 Group |
+| 顶栏 | `AppBar` / `SliverAppBar` |
+| 卡片 | `Card` / `Card.filled` / `Card.outlined` |
+| 筛选 | `FilterChip` / `ChoiceChip` / `SegmentedButton` |
+| 菜单 | `MenuAnchor` / `PopupMenuButton` |
+| 移动操作面板 | `showModalBottomSheet` |
+| 确认 | `AlertDialog` |
+| 提示 | `SnackBar` |
+| 进度 | `LinearProgressIndicator` / `CircularProgressIndicator` |
+| Tab | `TabBar` |
+| 搜索 | `SearchAnchor` / `SearchBar` |
+| 日期范围 | `DatePicker` / 自定义 Calendar Sheet |
+
+具体实现允许封装自有组件，但语义应保持 Material 3 一致。
+
+---
+
+## 11. 页面目录
+
+### Foundation
+
+- [App Shell、导航与响应式](./foundation/app-shell-navigation-responsive.md)
+
+### Access
+
+- [登录、服务端连接、安全与会话](./access/authentication-security.md)
+
+### Home
+
+- [首页、全局搜索、活动](./home/home-search-activity.md)
+
+### Library
+
+- [统一资源库、Resource 详情、Collection、标签与关系](./library/resource-library.md)
+
+### Video
+
+- [动画、影视、视频与播放器](./video/video-media.md)
+
+### Reading
+
+- [漫画、小说与阅读器](./reading/comic-novel-reading.md)
+
+### Music
+
+- [音乐库与播放器](./music/music-library-player.md)
+
+### Photos
+
+- [图片与相册](./photos/photo-album.md)
+
+### Documents
+
+- [文章、普通笔记、文档与轻量创作](./documents/document-creation.md)
+
+### Games
+
+- [游戏与数字资料](./games/game-digital-assets.md)
+
+### Productivity
+
+- [效率与计划](./productivity/productivity-planning.md)
+
+### Finance
+
+- [个人财务](./finance/personal-finance.md)
+
+### Private Notes
+
+- [私密笔记](./private-notes/private-notes.md)
+
+### Password Manager
+
+- [密码管理](./password-manager/password-manager.md)
+
+### AI
+
+- [AI Assistant、Persona、Memory 与隐私](./ai/ai-assistant-persona.md)
+
+### Analytics
+
+- [个人数据洞察](./analytics/analytics-insights.md)
+
+### Collaboration
+
+- [分享、Room 与评论](./collaboration/sharing-room-comments.md)
+
+### Automation
+
+- [Automation、Import / Sync 与集成](./automation/automation-sync-integrations.md)
+
+### Offline
+
+- [下载、缓存与离线](./offline/downloads-cache-offline.md)
+
+### Notifications
+
+- [通知中心](./notifications/notification-center.md)
+
+### Account
+
+- [个人资料与客户端设置](./account/profile-settings.md)
+
+---
+
+## 12. App 与 CMS 的职责边界
+
+当同一业务对象同时存在 App 与 CMS 页面时：
+
+- App 优先“消费、个人操作、轻量编辑、用户自己的安全与数据”。
+- CMS 优先“平台管理、批量治理、系统配置、全局运维、管理员审计”。
+- 两端使用同一业务 API 语义，不因为官方 App 而创造私有业务逻辑。
+
+例如：
+
+- App 可查看自己的 Automation Rule；CMS 可管理系统级 Rule。
+- App 可查看自己的 Session 并撤销；CMS 可查看有权限的系统会话治理页。
+- App 可查看自己的下载与缓存；CMS 管理 Storage Provider、Placement、GC。
+- App 可选择 Persona；CMS 管理 Persona 定义与发布版本。
+
+---
+
+## 13. 文档维护规则
+
+新增 App 页面时必须：
+
+1. 在本目录根页面目录登记。
+2. 放入对应子系统目录。
+3. 写明页面目的、入口、布局、组件、字段、状态、交互与响应式变化。
+4. 写明安全边界与离线语义（如果适用）。
+5. 如果页面依赖 V2 设计新增业务能力，应先更新对应 V2 产品 / 子系统文档，不在 UI 文档中偷偷创造新的业务事实。

--- a/docs/v2/app-interaction/access/authentication-security.md
+++ b/docs/v2/app-interaction/access/authentication-security.md
@@ -1,0 +1,267 @@
+# Access：登录、服务端连接、安全与会话
+
+## 1. 页面目录
+
+- Server Profile 列表。
+- 添加 / 编辑服务器。
+- 登录。
+- Email OTP / Step-up Verification。
+- 登录失败 / 兼容性错误。
+- 我的活跃会话。
+- 安全设置。
+- Secure Domain 恢复入口。
+
+---
+
+## 2. Server Profile 列表页
+
+### 2.1 入口
+
+- 首次启动。
+- 登录页左上角“切换服务器”。
+- 我的 → 客户端设置 → 服务器。
+
+### 2.2 页面结构
+
+App Bar：`服务器` + `添加`。
+
+列表卡片字段：
+
+- Server Display Name。
+- Base URL，展示 Host，完整 URL 放详情。
+- 当前连接状态：Online / Offline / Unknown。
+- 最近连接时间。
+- 当前账号名称（如已登录）。
+- 服务端版本。
+- `默认` Chip。
+
+卡片尾部更多菜单：编辑、设为默认、重新检测、移除本机配置。
+
+### 2.3 交互
+
+Tap 卡片：切换并尝试连接。
+
+移除只删除本机 Server Profile，不删除服务端账号；Dialog 必须明确这一点。
+
+---
+
+## 3. 添加服务器页
+
+### 3.1 表单字段
+
+1. `服务器地址 *`
+   - 支持 HTTPS / HTTP。
+   - 输入示例放 Helper Text，不预填真实域名。
+2. `名称`
+   - 可选；为空时连接成功后使用服务端返回名称或 Host。
+3. `高级选项` 折叠区：
+   - 自定义代理（如果客户端支持）。
+   - 是否允许本地开发环境 HTTP。
+   - 自签名证书策略只在开发 / 明确高级设置中出现。
+
+底部：`测试连接`、`保存并登录`。
+
+### 3.2 测试结果卡
+
+成功：
+
+- Server Name。
+- Version。
+- API Version。
+- Capability Discovery 摘要。
+- TLS 状态。
+
+失败：
+
+- DNS / Timeout / TLS / 版本不兼容分类。
+- `复制诊断信息`。
+
+---
+
+## 4. 登录页
+
+### 4.1 Layout
+
+Compact：单列，左右 24dp，表单最大宽度 480dp。
+
+Desktop：页面中央 420–480dp Login Card；左上角返回服务器列表。
+
+### 4.2 字段顺序
+
+1. 当前服务器小卡：Name + Host + `切换`。
+2. `用户名 / 邮箱 *`。
+3. `密码 *`，尾部 Reveal 图标。
+4. 可选 `保持登录`。
+5. `登录` Filled Button。
+6. `忘记密码 / 账号恢复` Text Button（服务端支持时）。
+
+不在第一屏直接显示 Secure Vault 解锁字段，因为 Ikaros Login 与 Vault Unlock 必须分离。
+
+### 4.3 交互
+
+- Enter 提交。
+- 提交时按钮 Loading。
+- 401：只显示“凭据无效”，不把服务端内部异常完整暴露。
+- 需要额外验证：转 Step-up 页面。
+- 成功：返回原 Deep Link 或首页。
+
+---
+
+## 5. Email OTP / Step-up Verification 页
+
+### 5.1 页面用途
+
+用于：
+
+- Login Step-up。
+- 修改安全设置。
+- Secure Recovery。
+- 高风险导出。
+- 其他要求 SVL 的动作。
+
+### 5.2 页面结构
+
+1. Shield 图标。
+2. 标题，例如“验证你的身份”。
+3. Purpose 文本，例如“为了导出密码保险库，需要重新验证”。
+4. 脱敏邮箱：`a***@example.com`。
+5. 6 位 OTP Input。
+6. `验证` Filled Button。
+7. 倒计时后 `重新发送`。
+8. `取消`。
+
+### 5.3 规则
+
+- 明确显示验证用途，不允许用户误以为验证码可用于任何操作。
+- 错误次数接近限制时显示剩余尝试次数（若安全策略允许）。
+- OTP 不进入剪贴板历史提示、Analytics 或普通日志。
+- 验证成功后自动回到原动作并继续。
+
+---
+
+## 6. 我的活跃会话页
+
+### 6.1 入口
+
+我的 → 安全与会话。
+
+### 6.2 页面字段
+
+顶部：
+
+- 当前账号。
+- `撤销其他会话` Outlined Button。
+
+每个 Session Card：
+
+- 设备类型图标。
+- Device Name。
+- Client：Android / Windows / iOS / Web 等。
+- 最近活动时间。
+- 大致位置 / IP 分类（服务端提供且允许时，不强求精确地址）。
+- 登录方式。
+- `当前设备` Chip。
+- 安全状态，例如“最近完成 Step-up”。
+
+### 6.3 交互
+
+Tap：打开 Session Detail Bottom Sheet / Side Sheet。
+
+非当前 Session：`撤销会话`。
+
+当前 Session：提供 `退出当前设备`，操作后返回登录页。
+
+`撤销其他会话` 必须 Dialog 确认，并说明不会删除账号数据。
+
+---
+
+## 7. 安全设置页
+
+分区：
+
+### 7.1 账号安全
+
+- 邮箱状态。
+- 修改密码。
+- 双重验证（当服务端支持）。
+- Recovery 设置。
+
+### 7.2 Step-up Verification
+
+只展示当前可用方式，例如 V2 初期 Email OTP。
+
+每项：
+
+- 方法。
+- 当前状态。
+- 最近验证。
+- 安全等级说明。
+
+### 7.3 本机解锁
+
+- 使用系统生物识别解锁 Password Manager。
+- 使用系统生物识别解锁 Private Notes。
+- App 回后台后自动锁定：立即 / 1 分钟 / 5 分钟 / 从不。
+- 阻止敏感页面截图（平台支持时）。
+
+这些开关只影响本机，必须标记 `此设备`。
+
+---
+
+## 8. Secure Domain 恢复页
+
+### 8.1 入口
+
+仅从 Private Notes / Password Manager 的“无法解锁？”进入，不放在普通首页显眼位置。
+
+### 8.2 第一屏必须解释
+
+- 账号恢复不等于加密数据恢复。
+- 当前 Vault 的 Security Profile。
+- 当前是否存在 Recovery Path。
+- Zero-knowledge 且无 Recovery Key 时，可能无法恢复历史数据。
+
+### 8.3 Recoverable Secure
+
+展示：
+
+- 当前 Recovery Policy。
+- 要求的 Verification Level。
+- `开始身份验证`。
+
+验证成功后再进入 Key Reset / Recovery 流程。
+
+### 8.4 Zero Knowledge
+
+展示可用方式：
+
+- Recovery Key。
+- Trusted Device。
+- Hardware Key（规划能力）。
+
+绝不显示“联系管理员重置密码即可恢复全部 Vault”之类误导文案。
+
+---
+
+## 9. 安全确认通用 Dialog
+
+高风险动作 Dialog 内容顺序：
+
+1. 动作名称。
+2. 影响对象。
+3. 是否可恢复。
+4. 对本地 / 服务端的影响。
+5. 必要的验证等级。
+6. Cancel。
+7. Continue。
+
+极高风险动作完成 Step-up 后，确认 Dialog 仍保留；身份验证不是操作确认的替代品。
+
+---
+
+## 10. 响应式
+
+- Compact：全屏独立页面。
+- Medium：表单居中，最大 560dp。
+- Expanded：安全设置可使用左侧 Section Navigation + 右侧设置内容。
+- Session 页在 >=840dp 使用列表 + 右侧详情 Pane。

--- a/docs/v2/app-interaction/account/profile-settings.md
+++ b/docs/v2/app-interaction/account/profile-settings.md
@@ -1,0 +1,300 @@
+# Account：个人资料与客户端设置
+
+## 1. 页面目录
+
+- 我的首页。
+- 个人资料。
+- 外观与语言。
+- 可访问性。
+- 通知偏好入口。
+- AI Persona / Privacy 入口。
+- 安全与会话入口。
+- Server Profiles。
+- Download / Cache 设置。
+- Local Device 设置。
+- App Update。
+- About / Diagnostics。
+
+App 不提供用户 / 角色 / 平台参数等管理员设置。
+
+---
+
+## 2. 我的首页
+
+### 2.1 Header
+
+- Avatar 72–88dp。
+- Display Name。
+- Username。
+- Short Introduction。
+- 当前 Server Name + Online Status。
+- `编辑资料`。
+
+### 2.2 快捷状态卡
+
+- Notifications 未读。
+- Downloads。
+- Pending Sync。
+- Active Sessions。
+
+只有有数据 / 异常时显示 Badge。
+
+### 2.3 设置分组
+
+#### Account
+
+- 个人资料。
+- 安全与会话。
+- 通知。
+
+#### Experience
+
+- 外观。
+- 语言。
+- 可访问性。
+- AI Persona / Privacy。
+
+#### Device
+
+- 下载与缓存。
+- 离线与同步。
+- 本机安全解锁。
+- Server Profiles。
+
+#### App
+
+- 检查更新。
+- Diagnostics。
+- About。
+- Logout。
+
+---
+
+## 3. 个人资料
+
+### 3.1 字段
+
+- Avatar。
+- Display Name。
+- Username（如果允许修改，单独说明规则）。
+- Introduction / Bio。
+- Email。
+- Locale。
+- Time Zone。
+
+Time Zone 会影响 Calendar / Analytics / Reminder，需要显示当前选择的示例时间。
+
+### 3.2 Avatar
+
+Tap：拍照 / 相册 / 文件；裁剪 1:1；Upload Progress；失败可重试。
+
+保存前 Preview。
+
+---
+
+## 4. 外观
+
+Settings：
+
+- Theme：System / Light / Dark。
+- Optional OLED Black（阅读器可以独立覆盖）。
+- Dynamic Color（平台支持时）。
+- App Accent / Seed Color（产品允许时）。
+- Compact Density（Desktop 可选）。
+- Reduce Motion：跟随系统 / On / Off。
+
+媒体播放器 / 阅读器拥有自己的沉浸主题，但返回 App 后恢复全局主题。
+
+---
+
+## 5. 语言与地区
+
+- App Language。
+- Content Preferred Language Order。
+- Date Format。
+- Time Format 12/24h。
+- First Day of Week。
+- Time Zone。
+
+Content Preferred Language 只影响显示标题优先级，不改 Resource 原始 Metadata。
+
+---
+
+## 6. 可访问性
+
+- Follow System Text Scale。
+- Additional Text Size（合理范围）。
+- High Contrast（产品支持）。
+- Reduce Motion。
+- Captions Preference。
+- Player Control Size。
+- Reader Touch Zone Guidance。
+
+提供 `预览` 卡，实时显示文字、按钮、Chip。
+
+---
+
+## 7. AI 设置入口
+
+Card 显示：
+
+- Current Persona。
+- Long-term Memory：On / Off。
+- Privacy Profile：Cloud Allowed / Local Only 等用户可理解摘要。
+
+Tap 进入 AI 专属 Persona / Memory / Privacy 页面，不在 Account 复制整套表单。
+
+---
+
+## 8. 安全与会话入口
+
+Card：
+
+- Active Session Count。
+- Current Verification Level / Recent Step-up 摘要。
+- Secure Domains：Locked / Unlocked（只显示状态，不显示内容）。
+
+Tap 进入 Access 文档定义的安全页。
+
+---
+
+## 9. 下载与缓存设置
+
+摘要：
+
+- Download Size。
+- Cache Size。
+- Free Space。
+
+入口：
+
+- My Downloads。
+- Cache Management。
+- Network Policy。
+- Auto Download。
+- Storage Location（Desktop / Android 能力允许时）。
+
+不要把 Cache Directory 直接当“下载目录”。
+
+---
+
+## 10. Offline / Sync 设置
+
+- Sync on Cellular。
+- Background Sync。
+- Pending Change Count。
+- Last Successful Sync。
+- `查看待同步`。
+
+Secure Domain Sync 设置放各 Vault 内，Account 只展示总状态。
+
+---
+
+## 11. Local Device Security
+
+标记 `仅此设备`。
+
+- App Lock。
+- Biometric Unlock for Password Manager。
+- Biometric Unlock for Private Notes。
+- Secure Auto-lock Timeout。
+- Hide Sensitive Recent Apps Preview。
+- Prevent Screenshot（支持时）。
+
+启用 Biometric 前执行系统能力检测和一次成功验证。
+
+---
+
+## 12. Server Profiles
+
+显示当前：Server Name、Host、Version、API Compatibility、Online State。
+
+操作：Switch Server、Manage Servers、Test Connection。
+
+切换 Server 前若存在 Pending Sync：Warning Sheet 显示数量，允许 Cancel / 继续切换；不能静默丢队列。
+
+---
+
+## 13. App Update
+
+### 13.1 Update Card
+
+- Current Version。
+- Build Number。
+- Channel：Stable / Beta（产品支持时）。
+- `检查更新`。
+
+### 13.2 Update Available
+
+Dialog / Page：
+
+- New Version。
+- Release Notes 摘要。
+- Download Size。
+- Platform Asset。
+- Compatibility Note。
+- `下载更新`。
+
+下载进度复用 Download / Background Progress 视觉；完成后平台支持时 `安装` / `重启更新`。
+
+不支持内更新的平台提供 `打开发布页面`。
+
+---
+
+## 14. Diagnostics
+
+用户可进入：
+
+- App Version。
+- Flutter / Platform Info（必要摘要）。
+- Server Host / Version。
+- API Compatibility。
+- Network State。
+- Last Sync。
+- Local DB / Cache Summary。
+- Notification Permission。
+- Media Capability Summary。
+
+操作：`复制诊断信息`。
+
+复制内容必须自动脱敏：Token、Password、Vault Data、完整 Secret、敏感 URL Query 不包含。
+
+---
+
+## 15. About
+
+- Ikaros Logo。
+- Version。
+- License。
+- Source Repository Link。
+- Documentation Link。
+- Open Source Notices。
+
+---
+
+## 16. Logout
+
+点击 Logout：
+
+Dialog 显示：
+
+- 将退出当前 Server Account。
+- Pending Sync Count。
+- 是否保留本机 Downloads。
+- Secure Encrypted Cache 的处理选项（按安全策略）。
+
+选项：
+
+- `退出并保留离线下载`（安全允许时）。
+- `退出并清除此账号本机数据`。
+
+Password / Private Vault 必须先 Lock，清理解密 Key Material。
+
+---
+
+## 17. 响应式
+
+- Compact：Settings 使用 Grouped List。
+- Medium：左 Section List、右 Detail。
+- Expanded：永久 Settings Navigation 260dp + 内容最大 760–900dp。
+- Large：设置表单仍限制宽度，右侧可显示 Preview / Help，不把开关分散到超宽行两端。

--- a/docs/v2/app-interaction/ai/ai-assistant-persona.md
+++ b/docs/v2/app-interaction/ai/ai-assistant-persona.md
@@ -1,0 +1,411 @@
+# AI：Assistant、Persona、Memory 与隐私
+
+## 1. App 定位
+
+AI 在 V2 中是横向能力，不是孤立聊天应用。App 提供统一 Assistant 入口，同时在 Resource、Editor、Planning、Analytics 等页面提供上下文 AI 操作。
+
+普通 App 负责：
+
+- Assistant 会话。
+- 用户选择 Persona。
+- 用户允许的 Persona 覆盖。
+- AI Memory 查看 / 编辑 / 删除。
+- Context / Privacy 选择。
+- Tool Action Draft 与确认。
+- AI Job 状态。
+- 用户 Feedback。
+
+Provider、Model Registry、全局 Budget、Prompt Definition 等管理员配置属于 CMS，不进入普通 App 主菜单。
+
+---
+
+## 2. 页面目录
+
+- AI Home / Conversation List。
+- Assistant Conversation。
+- Context Picker。
+- Tool Action Preview / Confirmation。
+- Persona Selector。
+- Persona Preference。
+- AI Memory。
+- AI Privacy。
+- AI Jobs。
+- AI Result Provenance。
+
+---
+
+## 3. AI Home
+
+### 3.1 App Bar
+
+- 标题 `Ikaros AI`。
+- New Conversation。
+- Search Conversations。
+- More：Archived、AI Settings。
+
+### 3.2 顶部 Persona Card
+
+- Persona Avatar。
+- Display Name，例如 Ikaros。
+- 当前 Scenario：General。
+- 当前 Model Profile（只显示用户可理解名称，可选）。
+- `切换人格`。
+
+### 3.3 快捷提示
+
+Chips / Cards：
+
+- 帮我规划今天。
+- 找最近没看完的内容。
+- 总结本周进展。
+- 找一个文档。
+- 解释数据趋势。
+
+建议项按已启用 Capability 生成；没有 Finance 权限时不出现财务快捷项。
+
+### 3.4 Conversation List
+
+- Title。
+- Last Message Preview。
+- Persona Avatar。
+- Scenario。
+- Updated At。
+- Pinned / Archived。
+
+---
+
+## 4. Conversation 页面布局
+
+### 4.1 Top Bar
+
+- Back / Conversation List。
+- Conversation Title。
+- Persona Chip。
+- Scenario Chip（有特殊场景时）。
+- More：Rename、Pin、Export、Archive、Clear Context Snapshot Info。
+
+### 4.2 Message Area
+
+User Message：普通 Surface。
+
+AI Message 包含：
+
+- Persona Avatar / Name。
+- Markdown 内容。
+- Source / Context Footnote。
+- Tool Call / Action Card（存在时）。
+- Model / Trace 信息折叠在 `详情`。
+- Feedback：Helpful / Not Helpful / Incorrect / Unsafe。
+- Copy。
+
+### 4.3 Composer
+
+从左到右 / 上到下：
+
+- `+` Context / Attachment。
+- 多行 Text Field。
+- Voice（未来可选）。
+- Send / Stop。
+
+Composer 上方显示 Context Chips，例如：
+
+- `当前资源：星海邮差`。
+- `文档：V2 Storage Review`。
+- `Task：T-104`。
+
+每个 Chip 可移除。
+
+---
+
+## 5. Context Picker
+
+Bottom Sheet / Side Sheet Tabs：
+
+- 当前页面。
+- Resource。
+- Document。
+- Collection。
+- Task / Goal。
+- Attachment。
+- Analytics Metric。
+- Activity（用户允许时）。
+
+每项显示：Title、Type、Permission / Data Classification、Selected Check。
+
+Private Notes / Password Manager：
+
+- 默认不可选。
+- 若 Private Notes 设置 Local Only AI，可在解锁后由 Private Notes 自身入口调用，不从通用 Context Picker 任意读取所有 Vault。
+- Password Secret Payload 不进入通用 AI Context。
+
+底部显示：`将向当前 AI Provider 使用 N 项上下文` + `查看隐私说明`。
+
+---
+
+## 6. AI Response 来源
+
+当回答基于 Ikaros 内容时，Message 底部显示 `来源` 折叠区：
+
+每条：
+
+- Resource / Document Icon。
+- Title。
+- Relevant Section / Chunk（可用时）。
+- `打开`。
+
+用户应能区分模型自由生成与 Retrieved Context。
+
+---
+
+## 7. Tool Call Card
+
+### 7.1 Read-only Tool
+
+例如 Search / Read Metric：
+
+Card：Tool Name、Purpose、Status、Result Summary。
+
+通常无需确认，但仍受权限约束。
+
+### 7.2 Low-risk Write Draft
+
+例如创建 Task：
+
+AI 先显示 Action Draft：
+
+```text
+创建任务
+标题：完成 V2 数据库设计
+截止：下周三
+预计：4 小时
+子任务：3 项
+```
+
+按钮：`确认创建`、`编辑`、`取消`。
+
+### 7.3 High-risk / Destructive
+
+例如 Archive Resource / Modify Permission：
+
+Card 使用 Warning / Error Container：
+
+- Action。
+- Target。
+- Effect。
+- Required Permission。
+- Risk Level。
+- 是否可恢复。
+- `继续验证`。
+
+完成 Step-up 后仍需最终 Confirm。
+
+AI 绝不因为 Persona 的“忠诚 / 主动”跳过确认。
+
+---
+
+## 8. Agent Progress
+
+多步骤 Agent 使用可折叠 Progress Card：
+
+- Goal。
+- Current Step。
+- Completed Steps。
+- Tool Calls。
+- Waiting for Confirmation。
+- Stop。
+
+默认只显示用户可理解步骤；`查看 Trace` 打开详细执行链路。
+
+停止 Agent 不回滚已经明确完成的外部副作用，UI 必须说明已完成哪些动作。
+
+---
+
+## 9. Persona Selector
+
+### 9.1 列表
+
+每个 Persona Card：
+
+- Avatar。
+- Display Name。
+- Short Description。
+- Style Tags，例如 Calm / Concise。
+- Published Version。
+- `当前` Chip。
+
+平台默认人格标 `Platform Default`。
+
+### 9.2 选择
+
+选择后：
+
+- 新 Conversation 默认使用新 Persona。
+- 当前 Conversation 若切换，显示 Confirm：“历史消息不会被改写，从下一条消息开始使用新 Persona。”
+- 记录新的 Persona Context Snapshot。
+
+---
+
+## 10. Persona Preference
+
+用户只能修改允许覆盖的部分：
+
+- Verbosity：简洁 / 平衡 / 详细。
+- User Address：自动 / 名称 / 昵称 / Master / Custom / None（Persona 支持时）。
+- Emoji：少 / 中 / 多。
+- Initiative：低 / 中 / 高。
+- Response Language。
+- Proactive Suggestions。
+
+顶部 Preview 显示当前 Effective Persona：Published Persona + User Override + Scenario Override。
+
+`重置为人格默认`。
+
+管理员定义的 Safety / Permission / Scenario Lock 不出现在可编辑控件中。
+
+---
+
+## 11. Scenario
+
+Assistant 会话可自动 / 手动显示 Scenario：
+
+- General。
+- Planning。
+- Writing。
+- Media Companion。
+- Focus。
+- Review。
+- Operations（管理员有权限场景）。
+- Security / Incident（由系统锁定）。
+
+Scenario 被系统锁定时 Chip 显示 Lock Icon，用户不能切回更轻松模式绕过安全表达要求。
+
+---
+
+## 12. AI Memory 页面
+
+### 12.1 Header
+
+- 标题 `AI 记忆`。
+- 总开关：Allow Long-term Memory。
+- `全部清除`。
+
+### 12.2 Memory Row
+
+- Memory Content Summary。
+- Scope：Global / Persona-scoped。
+- Created At。
+- Source Conversation。
+- Last Used（可用时）。
+- Edit。
+- Delete。
+
+### 12.3 Edit
+
+用户可直接修改 Memory 文本 / 结构化值，保存形成新版本 / Updated At。
+
+### 12.4 全部清除
+
+高影响但可理解的动作：Dialog 显示条数、范围；清除 AI Memory 不删除 Task / Resource / Profile 等业务状态。
+
+---
+
+## 13. AI Privacy 页面
+
+分区：
+
+### Data Usage
+
+- Allow Resource Metadata。
+- Allow Document Content。
+- Allow Activity。
+- Allow Analytics Metric。
+- Allow Attachments。
+- Allow Personalization / Recommendations。
+
+每项解释用途。
+
+### Provider Boundary
+
+显示用户当前可用 Provider Profile：
+
+- Cloud / Local。
+- Max Data Classification。
+- 是否允许 Attachment。
+
+用户不能在 App 中修改管理员 Credential，但可以选择“敏感内容只使用 Local Provider”等允许策略。
+
+### Logging
+
+- Save Prompt / Response History。
+- Save AI Trace（用户可见层面的设置，受管理员最小审计要求约束）。
+
+---
+
+## 14. AI Job
+
+### 14.1 List
+
+- Job Type：OCR / Transcript / Summary / Embedding / Metadata 等。
+- Target Resource。
+- Progress。
+- Status。
+- Started At。
+- Model / Provider（详情）。
+- Cancel（可取消时）。
+
+### 14.2 Detail
+
+- Input Scope。
+- Output Artifact。
+- Provenance。
+- Error Summary。
+- Retry。
+- Background Task Link。
+
+AI Job 完成后原始 Resource 不被自动覆盖；生成内容以 Artifact / Suggestion 形式展示。
+
+---
+
+## 15. AI Provenance
+
+生成 Metadata / Summary / Translation 等结果详情：
+
+- Provider。
+- Model。
+- Model Identifier / Version。
+- Prompt Version（用户可读名称优先）。
+- Created At。
+- Input Sources。
+- User / Automation / Agent。
+- Confidence：High / Medium / Low（有可靠语义时）。
+
+不伪造精确百分比可信度。
+
+---
+
+## 16. Natural Language Search / Planning
+
+在 Search / Planning 等页面调用 AI 时，结果保持在目标业务页面：
+
+- “找去年看过的时间循环动画” → Search Result。
+- “帮我安排明天上午” → Planning Draft。
+
+不强制把所有 AI 功能跳到 Chat 页面。
+
+---
+
+## 17. Offline
+
+- 已缓存 Conversation 可离线查看。
+- 没有本地模型时，发送按钮显示 `需要联网`。
+- Local Model 可用时按能力继续工作。
+- Tool Action 若目标业务支持 Offline Command，可创建 Pending Draft；高风险动作不在无法验证权限 / Step-up 时离线执行。
+
+---
+
+## 18. 响应式
+
+- Compact：Conversation 全屏，Context Picker Bottom Sheet。
+- Medium：Conversation + 可切换 Context Side Sheet。
+- Expanded：左 Conversation List 300dp、中 Chat、右 Context / Sources 320dp。
+- Large：消息正文限制最大可读宽度；Tool / Source Pane 常驻。

--- a/docs/v2/app-interaction/analytics/analytics-insights.md
+++ b/docs/v2/app-interaction/analytics/analytics-insights.md
@@ -1,0 +1,273 @@
+# Analytics：个人数据洞察
+
+## 1. App 边界
+
+App 的 Analytics 重点是“用户理解自己的内容、消费、创作、计划与本机存储使用”。
+
+系统级 Metric Catalog 管理、全局 Security Analytics、Operations 历史、系统报表重建属于 CMS。
+
+普通用户不得因为能看自己的 Insights 就获得系统管理员指标。
+
+---
+
+## 2. 页面目录
+
+- Insights Overview。
+- Content Insights。
+- Media Consumption。
+- Productivity Insights。
+- Creation Insights。
+- Local / Personal Storage Insights。
+- Metric Detail。
+- AI Explanation。
+
+Finance 的专业分析主要留在 Finance 子系统，但 Overview 可显示用户启用的安全摘要卡。
+
+---
+
+## 3. 全局筛选栏
+
+所有 Insights 页顶部统一：
+
+- Time Range：7D / 30D / 3M / 1Y / Custom。
+- Compare：Previous Period / Previous Year / Off。
+- Time Grain：Day / Week / Month（根据范围动态）。
+- Optional Dimension Filter。
+
+用户时区用于 Daily / Weekly 归属。
+
+Filter 改变后所有当前页面卡片同步刷新，并在 Header 显示实际日期范围。
+
+---
+
+## 4. Overview
+
+### 4.1 Compact 顺序
+
+1. 本周期摘要。
+2. 内容增长。
+3. 消费时间。
+4. Task / Focus。
+5. Creation。
+6. Storage / Download。
+7. AI Summary（可选）。
+
+### 4.2 摘要卡
+
+示例：
+
+- 新增 Resource `+42`。
+- 观看 `8h 20m`。
+- 阅读 `4h 10m`。
+- Focus `6h 40m`。
+
+每项显示 Comparison Arrow + 绝对差异 / 比例，但点击可打开 Metric Definition。
+
+不要把这些指标合成“个人效率 83 分”。
+
+---
+
+## 5. 图表通用组件
+
+每张 Chart Card 包含：
+
+- Metric Name。
+- 当前值。
+- Comparison。
+- Chart。
+- Info Icon。
+- More：View Data / Export / Explain with AI。
+
+### Accessibility
+
+Info / More → `查看数据表`，按时间列出数值。
+
+图表不只靠颜色区分 Series；Legend 使用名称 + Marker。
+
+---
+
+## 6. Metric Definition Sheet
+
+点击 Info：
+
+- Metric Name。
+- Description。
+- Unit。
+- Time Semantics。
+- Aggregation。
+- Supported Dimensions。
+- Data Source Summary。
+- Version。
+
+让用户能理解“完成率”等指标的口径。
+
+---
+
+## 7. Content Insights
+
+Cards：
+
+- Resource Total Trend。
+- New Resource Count。
+- Resource Type Distribution。
+- Archived / Trash Count。
+- Collection Count。
+- Tag Usage。
+- Metadata Completion（有正式 Metric 时）。
+- External Identity Coverage。
+
+Resource Type Distribution 点击类型跳转 Library Filtered View。
+
+---
+
+## 8. Media Consumption
+
+### Summary
+
+- Watch Duration。
+- Read Duration。
+- Listen Duration。
+- Completed Episodes / Movies / Chapters。
+
+### Charts
+
+- Daily Consumption Trend。
+- Time by Resource Type。
+- Completion Rate。
+- Continue Watching / Reading Count。
+- Most Accessed Resources。
+
+Most Accessed Resource Card：Cover、Title、Duration / Count、Open Resource。
+
+“打开播放器”不直接等于完成，页面只使用服务端正式 Metric。
+
+---
+
+## 9. Productivity Insights
+
+Cards / Charts：
+
+- Completed Task Count。
+- Completion Rate。
+- Overdue Count / Rate。
+- Planned Duration。
+- Actual Focus Duration。
+- Estimate Accuracy。
+- Time by Project。
+- Time by Goal。
+- Habit Completion / Streak。
+- Goal Progress Trend。
+- At Risk Goal Count。
+
+明确页脚：`这些指标用于帮助你理解行为，不代表个人能力或价值评分。`
+
+---
+
+## 10. Creation Insights
+
+- New Documents。
+- Published Articles。
+- Revision Count。
+- Creation / Focus Time。
+- Draft Count。
+- Word Count Trend（内容类型支持时）。
+- Collaboration Sessions。
+- Comments / Annotations。
+
+点击 Draft Count 跳 Document Draft Filter。
+
+---
+
+## 11. Personal Storage Insights
+
+普通 App 只展示与当前用户 / 本设备相关的用户语义：
+
+- My Downloads Size。
+- Client Cache Size。
+- Offline Resource Count。
+- Cache Hit Rate（服务端/客户端有正式用户级 Metric 时）。
+- Download Network Bytes（可用时）。
+
+不能把服务器 Hot / Warm / Archive 全局成本治理页直接放进普通 App。
+
+卡片底部快捷入口 `管理本机空间`。
+
+---
+
+## 12. Finance Summary
+
+默认关闭，可由用户设置开启。
+
+只显示：
+
+- 本月 Income / Expense。
+- Budget Usage。
+- Net Worth Trend。
+
+金额受 Finance 的 `隐藏金额` 设置影响。
+
+AI 总结是否可访问交易数据由 AI Data Policy 单独控制。
+
+---
+
+## 13. AI Explanation
+
+Chart More → `AI 解释`。
+
+Side Sheet / Bottom Sheet：
+
+- Metric Name / Current Value / Comparison 作为结构化输入。
+- 允许 AI 使用的 Related Metrics 列表。
+- Provider / Privacy 提示。
+- Generate。
+
+输出必须：
+
+- 明确是解释 / 推断。
+- 不创造不存在的数据。
+- 显示使用的 Metrics。
+- 可打开每个 Metric Detail。
+
+---
+
+## 14. Natural Language Query
+
+AI 可用时 Insights App Bar 提供 `问数据`：
+
+例如：`为什么这个月阅读时间下降？`
+
+系统先解析为 Metric / Dimension Query，展示查询口径，再生成解释。
+
+若数据不足，AI 应显示“不足以判断”，不能补造原因。
+
+---
+
+## 15. Privacy
+
+- Activity 可删除时，相应可重建统计按产品规则更新。
+- Private Notes 只进入最小 Count / Bytes / Sync Rate 等允许指标，不分析标题、标签、主题。
+- Password Manager Secret 不进入普通 Analytics。
+- Security / Login 管理指标只对授权管理员开放，普通 App 不显示。
+
+---
+
+## 16. Empty / Data Delay
+
+### No Data
+
+显示：`这个时间范围还没有足够数据` + 调整范围。
+
+### Processing Delay
+
+Analytics 最终一致性时：`数据更新至 10:20`。
+
+不要把短暂聚合延迟显示成业务对象状态错误。
+
+---
+
+## 17. 响应式
+
+- Compact：单列 Chart Card，高度 220–300dp。
+- Medium：2 列。
+- Expanded：12 列 Grid，关键趋势 8 列、摘要 4 列。
+- Large：图表最大宽度受控；右侧可固定 Metric Detail / AI Explanation。

--- a/docs/v2/app-interaction/automation/automation-sync-integrations.md
+++ b/docs/v2/app-interaction/automation/automation-sync-integrations.md
@@ -1,0 +1,440 @@
+# Automation：自动化、Import / Sync 与用户级集成
+
+## 1. App 边界
+
+App 负责用户自己的自动化与外部数据连接体验：
+
+- User Automation Rule。
+- Rule 执行历史。
+- Import。
+- Sync Relationship。
+- 冲突处理。
+- 用户有权使用的 Plugin / Connector。
+
+系统级 Automation、Plugin 安装 / 升级、Secret Provider 管理、Dead Letter Queue 全局治理等管理员能力属于 CMS。
+
+---
+
+## 2. 页面目录
+
+- Automation 列表。
+- Rule Builder。
+- Trigger Picker。
+- Condition Builder。
+- Action Builder。
+- Rule Review。
+- Execution History。
+- Execution Detail。
+- Import Center。
+- Import Preview。
+- Sync Source 列表。
+- Sync Detail / Conflict。
+- Integrations / Connectors。
+
+---
+
+## 3. Automation 列表
+
+### 3.1 App Bar
+
+- 标题 `自动化`。
+- Search。
+- Filter：Enabled / Disabled / Failed。
+- `新建`。
+
+### 3.2 Rule Card
+
+字段：
+
+- Rule Name。
+- Enabled Switch。
+- Trigger Summary。
+- Condition Count。
+- Action Summary。
+- Last Run。
+- Last Result：Success / Partial / Failed / Skipped。
+- Execution Count（可选）。
+- Owner：Me / Shared Context。
+- More。
+
+Enabled Switch 切换前若 Rule 当前为 Degraded / Missing Connector，显示原因，不允许“看起来开启但实际无法执行”。
+
+---
+
+## 4. 新建 Rule：步骤式 Builder
+
+使用 Stepper / 多页面 Flow：
+
+1. When。
+2. If。
+3. Then。
+4. Review。
+
+Mobile 每步全屏；Desktop 左侧 Steps 220dp、右侧编辑区。
+
+顶部始终显示 Draft Rule Name，可编辑。
+
+---
+
+## 5. Trigger Picker
+
+### 5.1 分类
+
+- Resource。
+- Media。
+- Planning。
+- Finance。
+- Storage User Events（有权限）。
+- Time / Schedule。
+- Webhook（能力允许）。
+- Plugin Event。
+- Manual Trigger。
+
+### 5.2 Trigger Card
+
+- Icon。
+- Name，例如 `新剧集创建`。
+- Event Key（Advanced 中）。
+- Description。
+- Provider / Plugin（扩展 Trigger）。
+- Required Permission。
+
+Tap 后进入 Trigger Config。
+
+### 5.3 Trigger Config
+
+按 Trigger 动态字段，例如 Scheduled Time：
+
+- Frequency。
+- Time。
+- Time Zone。
+- Start / End。
+
+Resource Event：
+
+- Resource Type。
+- Collection / Tag Scope。
+
+---
+
+## 6. Condition Builder
+
+### 6.1 行结构
+
+每条 Condition：
+
+1. Field / Capability。
+2. Operator。
+3. Value。
+4. Remove。
+
+例如：
+
+```text
+Resource.type = ANIME_EPISODE
+AND Parent.favorite = true
+```
+
+### 6.2 Group
+
+支持 AND / OR Group；Mobile 使用嵌套 Card，最大视觉缩进受限，深层逻辑转 Advanced Expression View。
+
+### 6.3 字段来源
+
+字段由公开 Capability / Event Schema 提供，UI 不允许用户选数据库表字段。
+
+---
+
+## 7. Action Builder
+
+Action 分类：
+
+- Create Task。
+- Complete Task。
+- Send Notification。
+- Add Tag。
+- Add to Collection。
+- Archive / Restore Resource。
+- Create Share。
+- Start Background Task。
+- Call Webhook。
+- Plugin Action。
+
+每个 Action Card 显示：
+
+- Name。
+- Target Scope。
+- Required Permission。
+- Risk Level。
+- Side Effect。
+
+高风险 Action 使用 Warning Icon。
+
+### 7.1 Action 参数
+
+例如 Create Task：
+
+- Title Template。
+- Project。
+- Scheduled / Deadline Rule。
+- Priority。
+- Related Resource = Trigger Resource。
+
+模板变量通过 Token Picker 插入，不要求用户手写 `${...}`。
+
+---
+
+## 8. Rule Review
+
+保存前必须展示可读规则：
+
+```text
+当：收藏动画出现新剧集
+如果：资源属于“2026 夏季观看”
+那么：
+  1. 创建任务“观看 {{episode.title}}”
+  2. 发送应用内通知
+```
+
+下方：
+
+- Owner / Principal。
+- Permissions Required。
+- Connected Services。
+- Risk Summary。
+- Rate Limit / Dedup Policy 摘要。
+
+按钮：`保存为禁用`、`保存并启用`。
+
+缺少权限时禁用“启用”，并说明缺什么。
+
+---
+
+## 9. AI Natural Language Automation
+
+Automation 首页 `用自然语言创建`：
+
+用户输入描述。
+
+AI 输出 Draft：Trigger、Conditions、Actions。
+
+必须进入同一个 Rule Review；AI 不能直接保存并启用 Rule。
+
+转换结果上标 `AI 生成草稿`。
+
+---
+
+## 10. Rule Detail
+
+Header：Name、Enabled、Edit、Run Now（支持 Manual Trigger / Test 时）、More。
+
+Sections：
+
+- Human-readable Rule。
+- Trigger Config。
+- Conditions。
+- Actions。
+- Permission Context。
+- Execution Policy。
+- Last Executions。
+
+若插件卸载 / Action 不可用：顶部 `Degraded` Banner + Missing Capability。
+
+---
+
+## 11. Execution History
+
+Filter：Status、Rule、Date。
+
+Row：
+
+- Status Icon。
+- Rule Name。
+- Trigger Time。
+- Duration。
+- Actions Success `2/2`。
+- Retry Count。
+- Correlation ID 仅 Advanced。
+
+状态：Pending / Running / Succeeded / Partial / Failed / Skipped / Cancelled。
+
+---
+
+## 12. Execution Detail
+
+### 12.1 Summary
+
+- Rule。
+- Execution ID。
+- Actor / On Behalf Of。
+- Trigger Event。
+- Start / End。
+- Final Status。
+
+### 12.2 Timeline
+
+按步骤：
+
+1. Trigger Received。
+2. Conditions Evaluated。
+3. Action 1。
+4. Action 2。
+5. Final Result。
+
+每步：Status、Duration、Result Summary、Retry。
+
+失败步骤可展开 Error Summary；Sensitive Secret 不写入页面。
+
+---
+
+## 13. Loop / Rate Protection
+
+Rule Detail Advanced 显示：
+
+- Max Chain Depth。
+- Re-entry Policy。
+- Dedup Window。
+- Throttle / Debounce。
+
+普通用户使用预设：`标准保护`，高级用户再展开细项。
+
+Rule 被 Loop Protection 阻止时 Execution 显示 `Skipped: Loop protection`，不记成模糊失败。
+
+---
+
+## 14. Import Center
+
+### 14.1 Source Cards
+
+- Device File。
+- Directory / Local Integration（Desktop）。
+- Object Storage / NAS Connector。
+- WebDAV。
+- Plugin Importer。
+- V1 Migration Importer（未来）。
+
+每卡显示 Provider、支持的数据类型、是否一次性 Import / 可建立 Sync。
+
+### 14.2 Import Flow
+
+1. 选择 Source。
+2. 选择范围。
+3. Parse / Scan。
+4. Preview。
+5. Dedup / Conflict Review。
+6. Confirm。
+7. Background Task。
+8. Result。
+
+---
+
+## 15. Import Preview
+
+顶部统计：
+
+- New Resource。
+- Update Candidate。
+- Duplicate Candidate。
+- Error。
+- Attachment Size。
+
+Item Row：
+
+- Source Item。
+- Detected Type。
+- Suggested Resource。
+- Metadata Source。
+- Duplicate Confidence / Reason（如有）。
+- Action：Import New / Merge Candidate / Skip。
+
+AI Duplicate Suggestion 明确标记 Candidate，不能自动合并。
+
+---
+
+## 16. Sync Source 列表
+
+每个 Sync Card：
+
+- Name。
+- Provider / Source Type。
+- Scope。
+- Enabled。
+- Last Sync Time。
+- Last Result。
+- Conflict Count。
+- Next Sync（有计划时）。
+- More。
+
+Import 与 Sync 使用不同 Icon / 文案；一次 Import 不显示“正在持续同步”。
+
+---
+
+## 17. Sync Detail
+
+Header：Name、Enabled、`立即同步`、More。
+
+Sections：
+
+- Source。
+- Scope。
+- Direction：One-way / Two-way（Provider 支持时）。
+- Mapping。
+- User Override Policy。
+- Last Runs。
+- Conflicts。
+- Credential Reference 状态。
+
+Credential 只显示 `已配置安全凭据`，不 Reveal Secret。
+
+---
+
+## 18. Metadata Conflict
+
+Conflict Card：
+
+- Resource。
+- Field。
+- Current Value。
+- Current Provenance。
+- External Value。
+- Provider。
+- Changed At。
+
+Actions：Keep Mine / Accept External / Resume Auto Sync。
+
+批量处理先预览字段数量与影响 Resource。
+
+---
+
+## 19. Integrations / Connectors
+
+普通 App 列出用户可连接的服务：
+
+- Provider Icon / Name。
+- Capability：Import / Sync / Calendar / Task / Search 等。
+- Connection Status。
+- Account / Safe Identifier。
+- Last Used。
+- Connect / Disconnect。
+
+安装 Plugin、更新插件代码、授予系统级权限仍跳 CMS / 管理端。
+
+Disconnect 确认说明：是否只断开认证、是否保留已经 Import 的 Resource、是否停止 Sync。
+
+---
+
+## 20. Offline
+
+- Rule List / History 可读缓存。
+- 创建 Rule Draft 可离线，但 `Enable` 需要能确认服务端 Schema / Permission 时才执行。
+- Import 本地文件可离线预处理，但正式纳入服务端需要连接。
+- Sync / Room / Webhook 操作离线不可运行，页面显示明确状态。
+
+---
+
+## 21. 响应式
+
+- Compact：Stepper 每步全屏；Execution Timeline 单列。
+- Medium：Rule List + Detail。
+- Expanded：左 Rule List、中 Builder、右 Schema / Preview Pane。
+- Large：Execution Detail 可左 Timeline 右 Raw / Advanced Detail，但默认不暴露低层 JSON。

--- a/docs/v2/app-interaction/collaboration/sharing-room-comments.md
+++ b/docs/v2/app-interaction/collaboration/sharing-room-comments.md
@@ -1,0 +1,313 @@
+# Collaboration：分享、Room、评论与协作
+
+## 1. 页面目录
+
+- 我的分享。
+- Create Share。
+- Share Detail。
+- Share Landing（登录用户客户端打开）。
+- Room 列表。
+- Create / Join Room。
+- Room Detail。
+- Room Chat / Event。
+- Document / Resource Comments。
+- Collaborator / Permission Sheet。
+
+Private Notes / Password Manager 的安全共享使用各自 Secure Domain 流程，不直接套用普通 Share Link。
+
+---
+
+## 2. 我的分享
+
+### 2.1 App Bar
+
+- 标题 `分享`。
+- Filter：Active / Expired / Revoked。
+- Create。
+
+### 2.2 Share Card
+
+字段：
+
+- Target Icon + Title。
+- Target Type：Resource / Collection / Document。
+- Permission Summary。
+- Expiration。
+- Access Count / Max Count（配置时）。
+- Download Allowed。
+- Password Protected Icon。
+- Status。
+- Created At。
+- More。
+
+More：Copy Link、Edit、View Access Summary、Revoke。
+
+---
+
+## 3. Create Share
+
+### 3.1 Target
+
+- 当前 Resource / Collection / Document 自动带入。
+- 可修改 Scope（允许时）。
+
+### 3.2 字段
+
+1. Expiration：1h / 24h / 7d / Custom / No Expiry（策略允许时）。
+2. Password Protection：Switch + Password / Generator。
+3. Allow Download：Switch。
+4. Maximum Access Count：Optional。
+5. Maximum Download Count：Optional。
+6. Content Scope：Current Only / Included Children / Selected Items。
+7. Optional Message。
+
+### 3.3 Preview
+
+创建前显示权限摘要：
+
+```text
+可查看：某 Collection 内 12 个 Resource
+可下载：否
+有效期：72 小时
+密码：是
+```
+
+`创建分享` 后显示 Link + QR（支持时）+ Copy。
+
+Share Token 不继承创建者其他权限，UI 用 Helper Text 解释。
+
+---
+
+## 4. Share Detail
+
+Header：Target、Status、Revoke。
+
+Sections：
+
+- Link / QR。
+- Permission。
+- Expiration。
+- Access / Download Count。
+- Created At / Updated At。
+- Recent Access Summary（权限与隐私允许时）。
+
+### Revoke
+
+确认文案：`撤销后该链接立即失效，不会删除原资源。`
+
+撤销可立即执行，不使用“删除资源”视觉语义。
+
+---
+
+## 5. Share Landing in App
+
+Deep Link 打开：
+
+1. 显示 Share Target Summary。
+2. 若需要密码，输入 Share Password。
+3. 显示 Share 权限范围。
+4. `打开内容`。
+
+若当前登录账号本身有更高权限，用户仍能以正常账号打开，但 Share Scope 的展示必须清楚，避免误认为 Token 提升账号权限。
+
+Expired / Revoked：显示明确状态与返回。
+
+---
+
+## 6. Room 列表
+
+Tabs：
+
+- Active。
+- Invited。
+- History。
+
+Room Card：
+
+- Room Name。
+- Type：Watch / Listen / General Queue。
+- Current Resource。
+- Host。
+- Member Avatar Stack + Count。
+- Status。
+- Last Activity。
+- `加入` / `继续`。
+
+---
+
+## 7. Create Room
+
+字段：
+
+- Room Name。
+- Room Type：Watch / Listen。
+- Initial Resource / Queue。
+- Persistent / Temporary（能力支持时）。
+- Invite Scope。
+- Member Playback Control：Host Only / Admin / All Members。
+- Chat Enabled。
+- `创建`。
+
+创建后进入 Room Detail / Player。
+
+---
+
+## 8. Join Room
+
+Invite Deep Link 页面：
+
+- Room Name。
+- Host。
+- Member Count。
+- Current Resource。
+- Required Permission Summary。
+- `加入房间`。
+
+若用户无 Resource READ / Stream 权限：
+
+- 显示“你可以加入房间，但无法访问当前媒体”或按服务端规则阻止加入。
+- 不由 Room 转发媒体内容绕过 ACL。
+
+---
+
+## 9. Room Detail Panel
+
+播放器中用 Side Sheet / Bottom Sheet；普通 Room 可独立页。
+
+Tabs：
+
+- Members。
+- Queue。
+- Chat。
+- Events。
+
+### Members
+
+每行：Avatar、Name、Role：Host / Admin / Member、Connection State、More。
+
+Host / Admin 可执行：Promote、Demote、Remove、Transfer Host（能力支持时）。
+
+### Queue
+
+Resource Card + Drag Handle + Added By + More。
+
+队列变更实时同步。
+
+### Chat
+
+Message：Author、Time、Body、Optional Resource Link。
+
+输入框：Text + Attachment / Resource Reference（允许时）。
+
+### Events
+
+系统事件：Member Joined、Paused、Seek、Resource Changed、Permission Changed。
+
+事件使用紧凑 Timeline，不和聊天正文完全混排。
+
+---
+
+## 10. Room 同步反馈
+
+播放器发生远端控制：
+
+- `房主已暂停`。
+- `房主跳转到 12:30`。
+- `队列切换为下一集`。
+
+短 Toast / Overlay 1–2 秒。
+
+本地网络抖动：
+
+- `正在重新连接房间`。
+- 重连成功后显示 `已同步到 12:32`。
+
+如果本地用户刚拖动进度但无控制权限，立刻回弹并显示权限解释，不假装成功后再跳回。
+
+---
+
+## 11. Comments
+
+### 11.1 Comment Panel
+
+可用于 Resource / Document / Task / Goal 等支持 Comment 的对象。
+
+顶部：Object Title、Comment Count、Sort。
+
+Comment Card：
+
+- Avatar。
+- Author。
+- Time。
+- Body。
+- Reply Count。
+- Resolved（批注类）。
+- More。
+
+### 11.2 Composer
+
+- Multiline Text。
+- Mention（支持时）。
+- Resource Link。
+- Submit。
+
+无 COMMENT Permission 时 Composer 替换成只读提示。
+
+---
+
+## 12. Collaborator Sheet
+
+显示：
+
+- Owner。
+- Members / Groups。
+- Role / ACL Summary。
+- Pending Invite。
+
+有 Manage Permission 时：Add Member、Change Permission、Remove。
+
+修改权限属于高风险动作时调用 Step-up / Confirmation Policy。
+
+---
+
+## 13. Document Collaboration
+
+- 在线协作者 Avatar Stack。
+- Cursor / Selection Presence。
+- Comments / Annotation。
+- Connection State。
+- Revision。
+
+离线后转 Local Edit；重新连接时若产生冲突，显示 Resolver，不因为 Room / Collaboration 存在就关闭 Revision 机制。
+
+---
+
+## 14. Notifications
+
+事件可产生：
+
+- Share 即将过期。
+- 新评论 / Reply。
+- Room Invite。
+- Room Started。
+- Permission Changed。
+
+Notification 点击 Deep Link 回对应对象。
+
+---
+
+## 15. Offline
+
+- Share 创建 / 修改需要在线确认服务端 Token 状态，离线时禁用并解释。
+- Room 必须在线。
+- 已缓存 Comment 可查看；新评论离线是否允许取决于同步能力，允许时标 Pending。
+- 文档本地编辑按 Documents Offline 规则。
+
+---
+
+## 16. 响应式
+
+- Compact：Room Panel Bottom Sheet / Fullscreen；Comments 独立页或 Bottom Sheet。
+- Medium：Player + Room Side Sheet。
+- Expanded：Room / Comments 320–400dp 常驻右栏。
+- Large：Members / Chat 可双栏，但媒体画面仍保持主要空间。

--- a/docs/v2/app-interaction/documents/document-creation.md
+++ b/docs/v2/app-interaction/documents/document-creation.md
@@ -1,0 +1,354 @@
+# Documents：文章、普通笔记、文档与轻量创作
+
+## 1. 页面目录
+
+- 文档首页。
+- 文档 / 文章列表。
+- 普通 Note 列表。
+- 文档详情。
+- 编辑器。
+- Revision 历史。
+- 评论 / 批注。
+- 发布设置。
+- 协作状态。
+
+本子系统仅描述普通 Document / Note / Article。高度敏感内容进入 Private Notes，不使用一个普通 `is_private` 开关替代安全域。
+
+---
+
+## 2. 文档首页
+
+### 2.1 App Bar
+
+- 标题：`文档与创作`。
+- Search。
+- `新建` Filled Button / FAB。
+- More：导入、模板、排序。
+
+### 2.2 顶部分段
+
+使用 Tabs / Segmented：
+
+- 最近。
+- 我的文档。
+- Note。
+- 文章。
+- 草稿。
+- 已发布。
+- 与我共享。
+
+### 2.3 最近文档卡片
+
+字段：
+
+- 类型图标：Document / Note / Article。
+- Title。
+- 摘要，最多 2 行。
+- Updated At。
+- Status：Draft / Published / Archived。
+- Collaborator Avatar Stack（存在协作时）。
+- Attachment Count。
+- Offline / Pending Sync 状态。
+
+Tap 打开详情或编辑器；More：重命名、移动到 Collection、分享、下载导出、归档、移入回收站。
+
+---
+
+## 3. 新建入口
+
+点击 `新建` 打开 Bottom Sheet / Menu：
+
+- 普通笔记。
+- 文档。
+- 文章 / 博客文章。
+- 从模板创建。
+- 从文件导入。
+- `私密笔记` 单独入口跳转 Private Notes，并标注“端到端加密”，不在普通 Document 中创建。
+
+选择后进入编辑器，未输入内容前返回可直接取消；已有内容时提示保存草稿 / 丢弃。
+
+---
+
+## 4. 文档详情页
+
+适用于只读查看状态。
+
+### 4.1 Header
+
+- 类型 Icon。
+- Title。
+- Status Chip。
+- Owner。
+- Last Updated。
+- `编辑` Filled Button（有权限）。
+- `分享`。
+- More。
+
+### 4.2 Metadata Bar
+
+横向 Wrap：
+
+- Tags。
+- Collection。
+- Language。
+- Revision Number。
+- Comment Count。
+- Attachment Count。
+
+### 4.3 正文
+
+按照文档内容结构渲染：Heading、Paragraph、List、Checklist、Table、Code Block、Callout、Image、Attachment、Resource Embed、Link。
+
+外链点击前按平台安全策略显示目标域名；Resource Embed 点击进入 Resource Detail。
+
+### 4.4 右侧 Context Pane（Desktop）
+
+Tabs：
+
+- Outline。
+- Comments。
+- Details。
+- Activity。
+
+Compact 使用 Bottom Sheet / 独立页。
+
+---
+
+## 5. 编辑器整体布局
+
+### 5.1 Compact
+
+```text
+┌───────────────────────┐
+│ Back  Draft  Save More│
+├───────────────────────┤
+│ Title                 │
+│ Metadata Chips        │
+├───────────────────────┤
+│                       │
+│ Editor Body           │
+│                       │
+├───────────────────────┤
+│ Context Toolbar       │
+└───────────────────────┘
+```
+
+### 5.2 Expanded
+
+三栏可选：
+
+- 左 240–300dp：Outline / Document Tree。
+- 中 640–900dp：正文编辑。
+- 右 300–360dp：Properties / Comments / AI。
+
+左右栏可收起，编辑正文始终保持主要宽度。
+
+---
+
+## 6. 编辑器顶部字段
+
+1. `Title *`：大号文本框；Enter 不提交页面。
+2. Status：Draft / Published / Archived；普通编辑时默认不允许直接点 Published，发布走 Publish Flow。
+3. Tag Chips：添加 / 删除。
+4. Collection：可选多选。
+5. Language / Locale。
+6. 可选 Cover / Hero Attachment。
+
+字段离焦后本地保存 Draft；不要每个按键都立即远端提交。
+
+---
+
+## 7. 编辑器 Toolbar
+
+根据编辑模式提供：
+
+- Undo / Redo。
+- Paragraph / Heading。
+- Bold / Italic / Strike。
+- Link。
+- Bullet / Numbered List。
+- Checklist。
+- Quote。
+- Code / Code Block。
+- Table。
+- Callout。
+- Image。
+- Attachment。
+- Embed Resource。
+- Mention / Collaborator（支持时）。
+- AI Assistant（用户开启时）。
+
+Mobile 使用横向可滚动 Bottom Toolbar；高频按钮固定，低频进入 `+` 菜单。
+
+---
+
+## 8. Attachment 插入
+
+点击 Attachment：
+
+- 从设备选择。
+- 从 Ikaros Attachment / Resource 选择。
+- 拍照 / 扫描（Mobile 支持时）。
+
+上传项显示：
+
+- Filename。
+- Size。
+- Upload Progress。
+- Cancel / Retry。
+
+完成后插入 Document Node，而不是把临时本地路径作为永久内容。
+
+图片支持 Alt Text / Caption。
+
+---
+
+## 9. Resource Embed
+
+选择 Resource 后插入卡片：
+
+- Cover / Icon。
+- Title。
+- Type。
+- Short Metadata。
+- Availability（必要时）。
+
+编辑器只保存 Resource 引用，不复制 Resource 元数据成为不可追踪快照，除非文档格式明确需要静态快照。
+
+---
+
+## 10. 保存与同步状态
+
+App Bar 标题附近显示状态：
+
+- `已保存`。
+- `正在保存…`。
+- `离线 · 已保存到本机`。
+- `待同步`。
+- `同步冲突`。
+- `保存失败`。
+
+离线编辑写本地队列；联网后同步。
+
+离开页面前如果本地保存成功，不以“远端暂时失败”阻止用户退出。
+
+---
+
+## 11. Revision 历史页
+
+### 11.1 列表
+
+每个 Revision：
+
+- Revision Number。
+- Timestamp。
+- Author。
+- Change Summary（可用时）。
+- AI Assisted / Human 标识（有 Provenance 时）。
+- `当前版本` Chip。
+
+### 11.2 详情
+
+Desktop：左右 Diff；Mobile：切换 Before / After / Diff。
+
+操作：
+
+- 查看此版本。
+- 与当前比较。
+- 恢复到此版本。
+
+恢复并不是删除后续历史；创建新的 Revision 表达恢复动作。
+
+---
+
+## 12. 评论 / 批注
+
+Comment 可绑定：
+
+- 整篇文档。
+- 选中文字 / Block。
+
+Comment Card：Avatar、Author、Time、Content、Resolved State、Reply Count。
+
+操作：回复、Resolve / Reopen、编辑自己的评论、删除自己的评论（按权限）。
+
+点击正文批注 Marker 高亮对应文本。
+
+---
+
+## 13. 协作状态
+
+实时协作可用时：
+
+- App Bar 显示在线协作者 Avatar Stack。
+- 点击打开 Collaborator Panel。
+- 正文 Cursor / Selection 使用明确身份颜色，但不只靠颜色，Hover / Tap 显示姓名。
+- 网络断开时显示“已切换本地编辑”，不静默丢内容。
+
+冲突无法自动合并时进入 Conflict Resolver，而不是 Last Write Wins。
+
+---
+
+## 14. Publish Flow
+
+Article / Blog 点击 `发布`：
+
+Bottom Sheet / Dialog 字段：
+
+- Publish Status。
+- Publish Time：立即 / 定时（能力支持时）。
+- Visibility / Permission。
+- Cover。
+- Summary / Excerpt。
+- Share / External Publish Provider（如插件可用）。
+
+底部先 `预览`，再 `发布`。
+
+若 AI 大幅参与内容，可显示 Provenance 选项，但最终内容仍归用户管理。
+
+---
+
+## 15. AI Writing Assistant
+
+入口：选中文字浮动菜单或侧栏。
+
+动作：
+
+- 改写。
+- 扩写。
+- 缩写。
+- 翻译。
+- 调整语气。
+- 语法检查。
+- 生成大纲。
+- 基于已授权 Resource 辅助写作。
+
+AI 结果以 Suggestion Card 显示：
+
+- 原文。
+- 建议文本。
+- 使用的 Model / Persona（详情中）。
+- 来源引用（存在时）。
+- `替换`、`插入下方`、`复制`、`丢弃`。
+
+不得自动覆盖用户正文。
+
+---
+
+## 16. Offline
+
+- 已同步文档可离线读取。
+- 用户明确 Pin / Download 的文档及附件离线可用。
+- 离线可新建、编辑、评论草稿（协作评论是否允许离线由 API 能力决定）。
+- Pending Change 必须可查看。
+
+普通 Document 本地缓存可被清理；用户主动下载 / Pin 的离线副本单独管理。
+
+---
+
+## 17. 响应式
+
+- Compact：单栏编辑器，Toolbar 底部。
+- Medium：正文 + 可切换 Side Sheet。
+- Expanded：Outline / Body / Context 三栏。
+- Large：正文仍限制可读宽度，右侧空余用于 Comments / AI，而不是拉宽段落。

--- a/docs/v2/app-interaction/finance/personal-finance.md
+++ b/docs/v2/app-interaction/finance/personal-finance.md
@@ -1,0 +1,426 @@
+# Finance：个人财务与记账
+
+## 1. 页面目录
+
+- Finance Dashboard。
+- Ledger 切换与管理。
+- Account 列表 / 详情。
+- Transaction 列表 / 详情。
+- Quick Add Transaction。
+- Split Transaction。
+- Scheduled Transaction。
+- Transaction Template。
+- Budget。
+- Reconciliation。
+- Import Preview。
+- Finance Insights。
+
+普通财务数据属于正常业务域；银行密码、PIN、API Token 等真正 Secret 通过 Password Manager / Secret Reference 使用，不复制明文到 Finance 表单。
+
+---
+
+## 2. Finance Dashboard
+
+### 2.1 App Bar
+
+- 当前 Ledger Selector。
+- Search。
+- Date Range。
+- More。
+
+主 FAB：`记一笔`。
+
+### 2.2 Compact 页面顺序
+
+1. Net Worth Card。
+2. 本月 Income / Expense / Net Cash Flow 三指标。
+3. Account Balance 横向列表。
+4. Budget Progress。
+5. Upcoming Bills。
+6. Cash Flow Mini Chart。
+7. Recent Transactions。
+
+### 2.3 Net Worth Card
+
+字段：
+
+- Net Worth。
+- Assets。
+- Liabilities。
+- Base Currency。
+- 与上期变化。
+
+金额可通过 App 级 `隐藏金额` 快捷按钮统一遮挡为 `••••`，但不改变数据权限。
+
+### 2.4 Account Balance Card
+
+- Account Icon。
+- Name。
+- Masked Identifier，例如 `•••• 1234`。
+- Current Balance。
+- Currency。
+- Credit Card 可显示 Available Credit / Statement Balance。
+
+Tap 进入 Account Detail。
+
+---
+
+## 3. Ledger Selector
+
+Bottom Sheet / Menu：
+
+- Ledger Name。
+- Base Currency。
+- Owner / Shared 标识。
+- 当前 Ledger Check。
+
+底部：`管理账本`。
+
+Ledger 管理页：Name、Base Currency、Members / Permission、Archived Status。
+
+切换 Ledger 后所有 Account / Transaction / Budget 查询切换到该账本，不把多个 Ledger 金额无意义混加。
+
+---
+
+## 4. Account 列表
+
+### 4.1 Group
+
+可按类型分组：Cash、Bank、Credit、E-wallet、Investment Tracking、Loan / Liability、Other。
+
+### 4.2 Account Row
+
+- Type Icon。
+- Name。
+- Masked Identifier。
+- Currency。
+- Current Balance。
+- Institution。
+- Archived Chip。
+- More。
+
+### 4.3 Create Account 字段
+
+1. Name *。
+2. Type *。
+3. Currency *。
+4. Opening Balance。
+5. Institution。
+6. Masked Identifier。
+7. Optional Secret Reference：`选择已保存凭据`，只展示 Vault Item 名称 / 安全引用，不展示 Secret。
+8. Type-specific Fields。
+
+Credit Card：Credit Limit、Billing Day、Due Day。
+
+Loan：Principal、Outstanding Balance、Payment Metadata。
+
+---
+
+## 5. Account Detail
+
+Header：Name、Masked ID、Balance、Currency、Institution、Edit。
+
+Sections：
+
+- Balance Trend。
+- Recent Transactions。
+- Upcoming Scheduled Transactions。
+- Reconciliation Status。
+- Related Receipts / Attachments。
+
+Credit Card 额外显示：Credit Limit、Available Credit、Statement Balance、Billing Day、Due Day。
+
+---
+
+## 6. Transaction 列表
+
+### 6.1 顶部
+
+- Search。
+- Date Range。
+- Filter。
+- Sort。
+
+Filter：Type、Account、Category、Tag、Payee、Currency、Source、Status。
+
+### 6.2 Transaction Row
+
+- Category Icon。
+- Payee / Title。
+- Category。
+- Account。
+- Occurred At。
+- Amount。
+- Currency。
+- Type Icon。
+- Receipt Indicator。
+- Imported / Manual Source（详情中优先，异常时可显示）。
+
+金额视觉：Income / Expense 使用正负号与 Icon，不仅靠绿色 / 红色。
+
+Transfer Row 同时显示 `Account A → Account B`，不伪装成一条支出。
+
+---
+
+## 7. Quick Add Transaction
+
+### 7.1 顶部 Type
+
+`SegmentedButton`：
+
+- 支出。
+- 收入。
+- 转账。
+- 调整（仅高级 / 有权限）。
+
+### 7.2 大金额输入
+
+页面顶部大号 Amount Field：
+
+- Currency Selector。
+- Decimal Keyboard（Mobile）。
+- 支持简单计算表达式可作为增强，不是 P0 必须。
+
+### 7.3 支出 / 收入字段
+
+1. Account *。
+2. Category。
+3. Payee。
+4. Occurred At *。
+5. Tags。
+6. Note。
+7. Receipt / Attachment。
+8. `拆分分类`。
+9. Source / Import 信息只读（编辑已导入项时）。
+
+### 7.4 Transfer 字段
+
+1. From Account *。
+2. To Account *。
+3. Amount *。
+4. Currency / Exchange Rate（跨币种）。
+5. Fee（可选）。
+6. Occurred At。
+7. Note。
+
+From 与 To 不能相同；选择后即时校验。
+
+### 7.5 保存
+
+- `保存` Filled Button。
+- `保存并再记一笔` 放 More。
+- Offline：保存本地 Pending Transaction 并明确显示待同步。
+
+---
+
+## 8. Split Transaction
+
+Sheet / 独立页：
+
+顶部显示总金额 `300.00` 与剩余待分配金额。
+
+每行：
+
+- Category。
+- Amount。
+- Note 可选。
+- Delete。
+
+底部：`添加拆分`。
+
+只有 `所有拆分金额之和 = 总金额` 才允许保存；差额实时显示。
+
+---
+
+## 9. Transaction Detail
+
+字段：
+
+- Type。
+- Amount / Currency。
+- Account / Target Account。
+- Category。
+- Payee。
+- Occurred At。
+- Tags。
+- Note。
+- Receipt Preview。
+- Source。
+- Import Batch（适用时）。
+- Created / Updated。
+
+操作：Edit、Duplicate、Create Template、Share Receipt（仅附件权限允许）、Delete。
+
+修改历史 Transaction 进入 Audit 的事实可在 UI 提醒“此修改会保留审计记录”。
+
+---
+
+## 10. Scheduled Transaction
+
+列表按 Upcoming Date 排序。
+
+Card：
+
+- Name / Template。
+- Next Occurrence。
+- Frequency。
+- Account。
+- Amount（可能为空）。
+- Mode：Create Draft / Notify / Auto Post（策略允许时）。
+- Enabled。
+
+编辑字段：Recurrence、Start / End、Template、Action Mode、Reminder。
+
+Scheduled Transaction 与已经发生的 Transaction 使用不同 Icon 和页面标题。
+
+---
+
+## 11. Transaction Template
+
+Card：Name、Type、Account、Category、Default Payee、Default Amount（可空）。
+
+点击 Template 直接打开预填 Quick Add；用户仍需确认实际发生时间 / 金额。
+
+---
+
+## 12. Budget
+
+### 12.1 Budget 首页
+
+Period Selector：Month / Quarter / Custom。
+
+Summary：Total Budget、Actual、Remaining、Overspent Count。
+
+### 12.2 Budget Card
+
+- Name / Category / Tag。
+- Budget Amount。
+- Actual。
+- Remaining。
+- Usage Rate Progress。
+- Forecast。
+- Period。
+
+达到 80% / 100% 用 Warning / Error Icon + 文本说明，不只改变进度条颜色。
+
+### 12.3 Create Budget
+
+字段：Scope（Ledger / Category / Tag / Project）、Target、Amount、Period、Carry-over Policy（若支持）、Alert Threshold。
+
+---
+
+## 13. Reconciliation
+
+### 13.1 列表
+
+Account、Statement Date、Calculated Balance、Statement Balance、Difference、Status。
+
+### 13.2 New Reconciliation
+
+1. Account。
+2. Statement Date。
+3. Statement Balance。
+4. System Calculated Balance 只读。
+5. Difference 自动计算。
+
+若 Difference != 0：
+
+- 显示差额。
+- `查看未核对交易`。
+- `创建 Adjustment`，必须用户明确确认。
+
+禁止按钮“自动修正历史交易”。
+
+---
+
+## 14. Import
+
+### 14.1 Import Source
+
+- CSV。
+- OFX / QFX / QIF（能力支持时）。
+- Plugin Provider。
+
+### 14.2 Mapping
+
+字段映射表：Source Column → Ikaros Field，支持日期格式、金额正负规则、Currency。
+
+### 14.3 Preview
+
+表格列：Date、Account、Amount、Type、Payee、Category、Duplicate Status、Error。
+
+顶部统计：Total、Ready、Possible Duplicate、Invalid。
+
+Possible Duplicate 展开显示匹配依据，不只写“重复”。
+
+### 14.4 Confirm
+
+用户可排除行，然后 `导入 N 条`。
+
+大批量导入创建 Background Task；完成后 Notification + Import Batch Detail。
+
+---
+
+## 15. Receipt / Attachment
+
+添加方式：相机拍摄、相册、文件。
+
+Upload / OCR 可后台执行。
+
+AI / OCR 建议字段显示 Candidate：Amount、Date、Payee、Tax 等；用户确认后才写 Transaction。
+
+真正高敏感附件可由用户转存 Secure Domain，并使用安全引用关联。
+
+---
+
+## 16. Finance Insights
+
+入口：Dashboard `查看分析`。
+
+Tabs：Cash Flow、Spending、Net Worth、Budget。
+
+统一 Time Range + Comparison。
+
+图表必须有文本摘要 / 数据表入口。
+
+AI 可解释趋势，但显示 `AI 解释` 标识，不能生成不存在的金额。
+
+---
+
+## 17. Secret 使用
+
+Account 中存在 `credential_ref` 时：
+
+- 显示 `已连接安全凭据：Bank API`。
+- 操作优先 `使用凭据重新连接`。
+- 不显示 `Reveal Token` 作为默认动作。
+- 需要 Reveal 时跳 Password Manager，并遵循 Vault Unlock / Step-up。
+
+---
+
+## 18. 隐私
+
+- Account Identifier 默认 Masked。
+- Notification 默认不显示完整卡号 / Secret。
+- App Switcher 金额隐藏可由用户设置，但这不是加密边界。
+- 导出账本属于敏感动作，可要求 Step-up。
+
+---
+
+## 19. Offline
+
+- Offline 可新增 Transaction。
+- 查看已缓存 Ledger / Account / Recent Transactions。
+- 编辑未同步的本地 Transaction。
+- 重新联网后同步 Queue。
+
+Reconciliation / Balance Adjustment 等高冲突操作离线时可禁用或创建明确 Draft，不静默在重连后覆盖服务端事实。
+
+---
+
+## 20. 响应式
+
+- Compact：Dashboard 单列；Quick Add 全屏 / Bottom Sheet；Transaction 列表卡片化。
+- Medium：Dashboard 2 列；账户与交易可 Master Detail。
+- Expanded：12 列 Dashboard；Transaction 使用 Data Table + Detail Pane。
+- Large：Chart 与 Table 并排，但金额列右对齐、列宽稳定。

--- a/docs/v2/app-interaction/foundation/app-shell-navigation-responsive.md
+++ b/docs/v2/app-interaction/foundation/app-shell-navigation-responsive.md
@@ -1,0 +1,307 @@
+# Foundation：App Shell、导航与响应式布局
+
+## 1. 页面与组件范围
+
+Foundation 不是业务菜单项，而是所有页面共同使用的 App Shell。
+
+包含：
+
+- 启动页 / Bootstrap。
+- 响应式主壳层。
+- 分组导航。
+- 全局 App Bar。
+- 全局搜索快捷入口。
+- Deep Link 路由。
+- Offline / Sync Banner。
+- 全局 Mini Player。
+- 全局安全锁定遮罩。
+- 键盘、鼠标、触摸基础交互。
+
+---
+
+## 2. 启动页 Bootstrap
+
+### 2.1 页面布局
+
+全屏 Surface，中心纵向排列：
+
+1. Ikaros Logo，72dp。
+2. `Ikaros` 产品名。
+3. 当前阶段文本，例如“正在连接家庭服务器”。
+4. 220–320dp 宽线性进度条。
+5. 底部版本号与“诊断”文本按钮，仅初始化超过合理时间或失败时显示。
+
+### 2.2 初始化顺序
+
+1. 加载本地 App Settings。
+2. 加载最近使用的 Server Profile。
+3. 加载本地认证状态。
+4. 加载离线数据库与下载索引。
+5. 如果可联网，执行服务器 Capability Discovery。
+6. 同步用户 Profile、菜单可用能力与未读通知数量。
+7. 若存在 Secure Domain，仅加载 Locked 元数据，不自动解密。
+8. 进入主壳层。
+
+### 2.3 状态
+
+- 无 Server Profile：转“添加服务器”。
+- Token 失效且在线：转登录页。
+- Token 失效但离线：允许进入离线模式，只展示本地可用能力。
+- 服务端版本不兼容：显示兼容性说明、服务器地址、客户端版本与升级动作。
+- Server 暂不可达：提供“离线进入”“重试”“切换服务器”。
+
+---
+
+## 3. Compact 主壳层 `<600dp`
+
+### 3.1 页面结构
+
+```text
+┌────────────────────────┐
+│ App Bar                │
+├────────────────────────┤
+│                        │
+│ Current Page           │
+│                        │
+├────────────────────────┤
+│ Mini Player (optional) │
+├────────────────────────┤
+│ Bottom Navigation      │
+└────────────────────────┘
+```
+
+### 3.2 Bottom Navigation
+
+固定 5 项：
+
+- 首页
+- 资源库
+- Today
+- AI
+- 我的
+
+每个 Destination：图标 + 标签。未读通知不占独立 Destination，通过“我的”或 App Bar Bell 显示徽标。
+
+### 3.3 Drawer
+
+App Bar 左侧菜单按钮打开全高 `NavigationDrawer`。
+
+Drawer 从上到下：
+
+1. 当前服务器卡片：服务器名称、URL Host、在线/离线圆点。
+2. 当前用户卡片：头像、Display Name。
+3. “切换服务器”小按钮。
+4. 可滚动分组菜单。
+5. 底部：下载、设置、关于。
+
+所有菜单分组默认收起。
+
+分组展开动画 180–240ms；展开后子项缩进 24dp。
+
+---
+
+## 4. Medium 主壳层 `600–839dp`
+
+左侧 `NavigationRail` 72–80dp：
+
+- 顶部 Menu。
+- 首页。
+- 资源库。
+- Today。
+- AI。
+- 我的。
+
+底部可放当前头像。
+
+点击 Menu 打开 320dp 宽 Drawer。内容区允许使用双栏，例如 Resource List + Preview Pane。
+
+---
+
+## 5. Expanded / Large 主壳层
+
+### 5.1 永久侧栏
+
+宽 280dp，Large 可 300dp。
+
+顶部：
+
+- Logo + Ikaros。
+- 当前服务器切换器。
+- 在线状态。
+
+中部：分组菜单。
+
+底部：
+
+- Download 状态按钮。
+- 用户头像、名称。
+- Settings 图标。
+
+### 5.2 菜单分组组件
+
+每一行高度 48dp：
+
+- 左：组图标 24dp。
+- 中：组名。
+- 可选：徽标，例如“3”。
+- 右：Chevron。
+
+点击整行切换展开。
+
+子项高度 44dp：
+
+- 左侧 24dp 缩进。
+- 当前项使用 Secondary Container 背景。
+- Hover 显示 State Layer。
+- Focus 可用键盘上下导航。
+
+### 5.3 默认收起语义
+
+- 新安装：全部收起。
+- 用户主动展开状态可本地记忆。
+- 若用户启用“每次启动收起菜单”，每次重启恢复全部收起。
+- Deep Link 可临时展开当前组，但不覆盖用户持久化偏好。
+
+---
+
+## 6. 内容容器
+
+Expanded / Large：
+
+- 页面内容左右 Padding 24–32dp。
+- 主内容最大宽度建议 1440dp。
+- 阅读/编辑等沉浸页可突破最大宽度规则。
+- 表单主体建议 720–960dp，避免在 4K 屏上拉得过宽。
+
+支持三种页面框架：
+
+### A. List Page
+
+App Bar + Filter + Content List/Grid。
+
+### B. Master Detail
+
+左 360–480dp List，右侧 Detail。
+
+### C. Immersive
+
+播放器、阅读器、编辑器使用全内容区域，并降低 Shell 导航视觉权重。
+
+---
+
+## 7. 全局 Mini Player
+
+音频播放时可出现。
+
+### Compact
+
+位于 Bottom Navigation 上方，高 64dp：
+
+- 48dp 封面。
+- 标题一行。
+- 副标题一行。
+- Play/Pause。
+- 下一首。
+- 底部 2dp 进度条。
+
+Tap 整体进入 Now Playing。
+
+### Desktop
+
+放在侧栏底部或内容底部浮条，宽度不挤压主内容。支持 Hover 显示更多控制。
+
+视频默认不使用持续 Mini Player；若未来支持 PiP，按系统能力单独实现。
+
+---
+
+## 8. 全局 Offline / Sync Banner
+
+### 8.1 Offline
+
+顶部紧贴 App Bar 下方，使用 Surface Container：
+
+- 离线图标。
+- “当前离线，正在使用本地内容”。
+- `查看待同步 4 项`。
+- 关闭图标只隐藏本次提示，不改变离线状态。
+
+### 8.2 Sync Error
+
+显示错误数量：
+
+- “3 项变更同步失败”。
+- `查看`。
+- 不以红色全屏阻断正常离线读取。
+
+---
+
+## 9. 全局安全锁定
+
+当 App 进入后台，若用户启用“离开 App 自动锁定 Secure Domain”：
+
+- Private Notes 与 Password Manager 的解密 Widget 必须销毁。
+- 最近任务预览隐藏敏感内容。
+- 返回 App 时可在当前页面上覆盖 Secure Lock Surface。
+- 普通 Library 内容不受影响。
+
+锁定不是退出登录。
+
+---
+
+## 10. Deep Link
+
+至少规划：
+
+- Resource Detail。
+- Task / Project。
+- Notification Target。
+- Share。
+- Room Invite。
+- AI Conversation。
+- Private Note（先进入解锁）。
+- Vault Item（先进入解锁）。
+
+Deep Link 流程：
+
+1. 解析目标。
+2. 校验当前 Server Profile。
+3. 校验登录 / 权限。
+4. 校验 Secure Unlock（如需要）。
+5. 跳转目标。
+6. 失败时显示可理解的错误页，不静默回首页。
+
+---
+
+## 11. 键盘与鼠标
+
+Desktop 必须支持：
+
+- `Ctrl/Cmd + K`：全局搜索。
+- `Ctrl/Cmd + N`：在当前支持的业务页新增对象。
+- `Esc`：关闭 Menu / Dialog / Bottom Sheet；沉浸页优先退出控制层。
+- `Alt + Left`：返回。
+- `Ctrl/Cmd + ,`：设置。
+- `Space`：播放器页面播放/暂停；表单输入焦点时不拦截。
+- Tab Focus Order 与视觉顺序一致。
+
+右键用于非破坏性上下文菜单；破坏性操作仍需要确认。
+
+---
+
+## 12. Touch
+
+- 主要触控目标最小 48×48dp。
+- 长按只打开 Action Sheet，不直接删除、分享或 Reveal Secret。
+- 横向 Swipe 只用于明确可逆动作，例如 Task 完成 / 稍后；必须支持 Undo。
+- 阅读器与播放器可以使用自定义手势，但不能与系统返回手势冲突。
+
+---
+
+## 13. 可访问性
+
+- 所有图标按钮提供 Tooltip / Semantic Label。
+- 颜色不是唯一状态表达方式。
+- 支持系统字体缩放，关键按钮不可因 200% 文本而消失。
+- 动效尊重 Reduce Motion。
+- 播放器、阅读器提供键盘可访问控制。
+- 图表提供文本摘要与数值列表入口。

--- a/docs/v2/app-interaction/games/game-digital-assets.md
+++ b/docs/v2/app-interaction/games/game-digital-assets.md
@@ -1,0 +1,236 @@
+# Games：游戏与数字资料
+
+## 1. 页面目录
+
+- 游戏库。
+- 游戏详情。
+- 版本 / 平台列表。
+- 数字资料与附件。
+- MOD / Patch / Save 分类页。
+- 下载与归档状态。
+
+Ikaros V2 的定位是游戏数字资产归档与检索平台，不强制承担完整游戏启动器职责。
+
+---
+
+## 2. 游戏库
+
+### 2.1 App Bar
+
+- 标题 `游戏`。
+- Search。
+- Filter。
+- Sort。
+- View Toggle。
+
+### 2.2 Game Card
+
+- Cover / Key Art。
+- Title。
+- Platform Chips，例如 Windows / Switch / PS。
+- Version 摘要。
+- Favorite。
+- Availability。
+- Attachment Count。
+- Archive 状态。
+
+Tap 进入详情。
+
+---
+
+## 3. Filter
+
+- Platform。
+- Genre / Tag。
+- Collection。
+- Installed Package Available（只表示附件存在，不表示本机已安装）。
+- Has Save Backup。
+- Has MOD。
+- Availability。
+- Lifecycle。
+
+“已安装”仅当未来明确存在本地集成并能可靠判断时显示，当前不从安装包存在推断。
+
+---
+
+## 4. 游戏详情 Header
+
+Compact 纵向，Desktop 左图右信息。
+
+字段：
+
+- Cover。
+- Display Title。
+- Original / Alternative Title。
+- Developer / Publisher。
+- Release Date。
+- Platform。
+- Version / Edition。
+- Tags。
+- Favorite。
+- `查看资料` 主按钮。
+- Download。
+- Share。
+- More。
+
+若配置了外部 Launcher / Plugin，可在 More 显示 `使用 xxx 打开`，不能把插件动作伪装为 Ikaros 原生安装状态。
+
+---
+
+## 5. 详情 Tabs
+
+- 概览。
+- 资料。
+- 版本。
+- 关联。
+- 信息。
+
+### 概览
+
+- Description。
+- Current Version Summary。
+- Recent Assets。
+- Related Resource。
+- Notes / Documents Preview。
+
+---
+
+## 6. 数字资料分类
+
+资料页顶部 Category Chips：
+
+- 安装包。
+- Patch / Update。
+- MOD。
+- Save Backup。
+- Manual / Document。
+- Screenshot / Media。
+- Archive / Other。
+
+每个 Attachment Row：
+
+- 类型图标。
+- Display Name。
+- Version。
+- Platform。
+- Size。
+- Added At。
+- Availability。
+- Download State。
+- Checksum Verified 状态（如果服务端提供用户语义）。
+- More。
+
+---
+
+## 7. Attachment 操作
+
+More：
+
+- Download。
+- Share（权限允许）。
+- Open With（本机支持）。
+- 查看信息。
+- 关联到 Version。
+- Archive / Restore（有权限）。
+
+如果 Attachment 为 Archive / Cold：点击 Download 先进入 Restore Sheet：
+
+- 当前状态。
+- `开始恢复`。
+- 恢复完成通知。
+
+恢复完成后再下载，不把 Restoring 显示为“下载 0%”。
+
+---
+
+## 8. Version / Edition
+
+版本卡片字段：
+
+- Name / Version。
+- Platform。
+- Release Date。
+- Region / Language（适用时）。
+- Related Attachments Count。
+- Preferred 标识。
+
+Tap 进入版本详情，列出 Installer、Patch、MOD Compatibility、Docs。
+
+---
+
+## 9. MOD 页面
+
+MOD Card：
+
+- Name。
+- Version。
+- Compatible Game Version。
+- Author / Source。
+- Description。
+- Attachment Size。
+- Availability。
+- Download。
+
+Ikaros 默认只管理资料，不自动修改游戏目录。若插件提供安装能力，必须明确标识“由插件执行”，并在操作前预览目标路径 / 影响。
+
+---
+
+## 10. Save Backup
+
+每个 Save Backup：
+
+- Name。
+- Game Version。
+- Created / Imported At。
+- Device / Source（可用时）。
+- Size。
+- Notes。
+- Download。
+
+恢复到本机属于高风险本地覆盖动作时：
+
+- 先展示目标路径。
+- 是否覆盖已有存档。
+- 可选先创建本地备份。
+- 用户确认后执行。
+
+---
+
+## 11. Manual / Document
+
+PDF / README / Guide 使用 Document Viewer。
+
+若关联普通 Ikaros Document，点击打开 Document 页面；若是 Attachment，使用合适 Viewer / 系统打开。
+
+---
+
+## 12. Search
+
+游戏内搜索范围：
+
+- Title / Alias。
+- Platform。
+- Version。
+- Asset Name。
+- Tag。
+- External Identity。
+
+Search Result 必须区分 Game Resource 与 Attachment。
+
+---
+
+## 13. Offline
+
+- 已下载 Installer / MOD / Save 明确进入“我的下载”。
+- Cache 只用于预览与临时打开，不标记为 Downloaded。
+- 游戏资料的大对象下载支持暂停、恢复、失败重试。
+- Offline 时仍可浏览本地索引与已下载资料。
+
+---
+
+## 14. 响应式
+
+- Compact：Game Grid 2 列或自适应；详情单列。
+- Medium：详情 Header 两列。
+- Expanded：左侧 Game List / Filter，右侧详情；资料页可使用 Data Table。
+- Large：附件表格保持列宽上限，长名称优先 Title 列伸缩。

--- a/docs/v2/app-interaction/home/home-search-activity.md
+++ b/docs/v2/app-interaction/home/home-search-activity.md
@@ -1,0 +1,267 @@
+# Home：首页、全局搜索与我的活动
+
+## 1. 页面目录
+
+- Home Dashboard。
+- 全局搜索。
+- 搜索筛选页 / Sheet。
+- 我的 Activity Timeline。
+- Continue Center。
+
+---
+
+## 2. Home Dashboard
+
+首页不是系统管理 Dashboard，而是个人内容与行动入口。
+
+### 2.1 App Bar
+
+从左到右：
+
+- Menu / Logo。
+- `早上好 / 下午好 / 晚上好` + 用户 Display Name，Desktop 可简化为 `首页`。
+- Search。
+- Notification Bell + 未读 Badge。
+- 可选头像。
+
+### 2.2 Compact 布局顺序
+
+1. 全局 Search Bar。
+2. Today Summary Card。
+3. Continue 区域。
+4. Quick Actions。
+5. 最近添加。
+6. 我的收藏 / 最近 Collection。
+7. AI Brief（用户开启时）。
+8. 最近 Activity。
+
+### 2.3 Today Summary Card
+
+字段：
+
+- 日期、星期。
+- Today Task：完成 / 总数。
+- 下一 Calendar Event / Time Block。
+- Overdue 数。
+- Habit 待打卡数。
+- 可选 Upcoming Bill。
+
+底部操作：`打开 Today`。
+
+若用户未启用 Productivity，则整卡隐藏，不留空占位。
+
+### 2.4 Continue 区域
+
+横向卡片，可混合但明确类型：
+
+- Continue Watching。
+- Continue Reading。
+- Continue Listening。
+- Continue Editing。
+
+卡片字段：封面、类型、标题、当前进度、最后活动时间。
+
+Tap 直接进入对应消费 / 编辑页面，而不是先回 Resource Detail；长按可“查看详情”。
+
+### 2.5 Quick Actions
+
+Compact 使用 2×N Grid；Desktop 使用横向按钮组。
+
+默认：
+
+- 新建 Task。
+- 记一笔。
+- 新建笔记。
+- 扫码 / 导入（支持时）。
+- AI Assistant。
+
+允许用户在设置中排序和隐藏，不允许添加无权限动作。
+
+### 2.6 最近添加
+
+显示 6–12 个 Resource Card。
+
+Header：`最近添加` + `查看全部`。
+
+### 2.7 AI Brief
+
+仅用户开启 AI Daily Brief 时展示。
+
+内容最多 3–5 条：
+
+- 今日重要 Task。
+- 冲突。
+- 新增喜欢内容。
+- 需要关注的通知。
+
+卡底部：`和 Ikaros 继续聊`。
+
+AI Brief 必须明显标注 AI 生成，不把推断当业务事实。
+
+### 2.8 Desktop
+
+>=1200dp 首页使用 12 列 Grid：
+
+- 左 8 列：Continue、最近添加、Activity。
+- 右 4 列：Today、Quick Actions、AI Brief。
+
+所有卡片顶部对齐，避免瀑布式随机高度导致阅读跳跃。
+
+---
+
+## 3. 全局搜索页
+
+### 3.1 顶部
+
+- 返回。
+- Search Bar 自动聚焦。
+- Clear。
+- Voice Search（未来能力，不作为 P0 必需）。
+- Filter。
+
+Desktop 可在 Search Bar 右侧显示快捷键提示 `Ctrl K`。
+
+### 3.2 Search Suggestion
+
+输入前：
+
+- 最近搜索。
+- 最近访问。
+- 常用标签。
+- 可选保存的搜索。
+
+输入后：
+
+- 即时建议标题 / 别名。
+- 仅在 debounce 后请求远端。
+- 支持键盘上下选择。
+
+### 3.3 搜索结果分区
+
+顶部 Segmented / Tabs：
+
+- 全部
+- Resource
+- 文档
+- Task
+- Collection
+- 其他
+
+结果卡必须显示对象类型，避免同名对象不可辨识。
+
+Resource 结果字段：封面、标题、多语言匹配说明、类型、Collection、可用状态、消费进度。
+
+Task：状态 Checkbox、标题、Project、Scheduled / Deadline。
+
+Document：图标、标题、摘要、更新时间、类型。
+
+### 3.4 私密结果
+
+未解锁 Private Notes：
+
+```text
+[锁] 私密笔记
+发现可能的本地匹配结果
+[解锁查看]
+```
+
+不得显示标题、标签、正文片段。
+
+Password Manager 默认不参与普通内容搜索。只有用户在 Password Manager 内部搜索。
+
+### 3.5 筛选
+
+Filter Sheet / Side Sheet 字段：
+
+- Resource Type，多选。
+- 时间范围。
+- 标签，多选。
+- Collection。
+- 收藏状态。
+- Lifecycle：Active / Archived / Trash（有权限时）。
+- Availability：Available / Cached / Remote / Restoring 等。
+- Source：Local / Provider / Plugin（适用时）。
+- Sort：Relevance / Recently Updated / Recently Added / Title。
+
+底部：`重置`、`应用`。
+
+Desktop 筛选可以固定在右侧 320dp Pane。
+
+---
+
+## 4. 搜索零结果
+
+显示：
+
+- `没有找到“xxx”`。
+- 建议检查拼写、清除筛选。
+- `在外部 Provider 搜索`（安装对应 Search Provider 时）。
+- `让 AI 帮我找`（AI 可用时），但必须说明这会使用不同的语义检索方式。
+
+---
+
+## 5. 我的 Activity Timeline
+
+### 5.1 页面目标
+
+聚合用户业务行为，不与管理员 Audit 混淆。
+
+### 5.2 顶部筛选
+
+- Today / 7 Days / 30 Days / Custom。
+- 类型：播放、阅读、编辑、Task、Goal、Focus、Finance（仅适合的非敏感摘要）、其他。
+
+### 5.3 Timeline Item
+
+字段：
+
+- 时间。
+- 类型图标。
+- 动作文本，例如“看完第 8 集”。
+- 目标对象标题。
+- 可选 Duration / Progress。
+- 来源客户端。
+- More。
+
+Private Notes 默认只显示“更新了私密笔记”，不显示标题；用户可以完全关闭该类 Activity。
+
+### 5.4 删除 Activity
+
+用户可删除允许删除的个人历史：
+
+- 单条 More → 删除。
+- 筛选后批量清理。
+
+Dialog 明确：这不会删除 Resource / Task，只删除活动历史。
+
+---
+
+## 6. Continue Center
+
+当 Continue 项目较多时从首页“查看全部”进入。
+
+Tabs：
+
+- 观看
+- 阅读
+- 收听
+- 编辑
+
+每项显示：
+
+- Resource。
+- Progress。
+- Last Activity。
+- 本地可用状态。
+- `继续` 主按钮。
+- More：从继续列表移除、查看详情、下载。
+
+离线时优先把已下载 / 已缓存且可完整读取内容排在前面，并显示 `离线可用` Chip。
+
+---
+
+## 7. 状态与响应式
+
+- 首页每个模块独立加载，某一模块失败不阻断整个首页。
+- Desktop 支持用户调整首页 Card 顺序；Mobile 只允许在“首页布局设置”中重排，避免误拖。
+- Home 不显示系统级运维图表；管理员异常通过普通 Notification / Alert 摘要进入用户允许的入口。

--- a/docs/v2/app-interaction/library/resource-library.md
+++ b/docs/v2/app-interaction/library/resource-library.md
@@ -1,0 +1,424 @@
+# Library：统一资源库、Resource 详情、Collection、标签与关系
+
+## 1. 页面目录
+
+- 统一资源库。
+- Resource 通用详情。
+- Resource 元数据详情。
+- 外部身份与来源。
+- Collection 列表。
+- Collection 详情。
+- 标签浏览。
+- Relation 关系浏览。
+- 生命周期操作 Sheet。
+
+Resource 的专业消费界面由对应子系统继续细化：Video、Reading、Music、Photos、Documents、Games。
+
+---
+
+## 2. 统一资源库页
+
+### 2.1 App Bar
+
+- 标题：`资源库`。
+- Search。
+- View Toggle：Grid / List（Desktop 可常驻，Mobile 放 More）。
+- Sort。
+- Filter。
+
+### 2.2 顶部快捷筛选
+
+横向 `FilterChip`：
+
+- 全部
+- 收藏
+- 最近添加
+- 最近访问
+- 已下载
+- 离线可用
+
+第二行类型 Chip 允许横向滚动：视频、动画、电影、漫画、小说、音乐、图片、文档、游戏、其他。
+
+### 2.3 Grid Card
+
+通用字段：
+
+- 封面。
+- Resource Type 小图标 / Chip。
+- 标题。
+- 可选第二标题。
+- 关键元信息，例如年份、作者、艺术家。
+- Progress。
+- Availability Chip，仅状态非普通 Available 时显示。
+- Favorite 图标。
+
+#### 封面比例
+
+- 海报类：2:3。
+- 专辑 / 图片：1:1。
+- 文档：卡片图标 + 4:3 Preview。
+- 通用视频：16:9。
+
+网格必须允许不同类型按类型模板渲染，但卡片底部信息区高度保持稳定。
+
+### 2.4 List Row
+
+- 72dp Thumbnail。
+- Title。
+- Type + Meta。
+- Collection / Tags 摘要。
+- Availability。
+- Updated At。
+- Progress（适用时）。
+- More。
+
+### 2.5 分页 / 无限加载
+
+Mobile 默认 Infinite Scroll；Desktop 可以 Infinite Scroll 或分页，但同一客户端内保持一致。
+
+Loading More 只在列表底部显示，不重新 Skeleton 已加载项目。
+
+---
+
+## 3. Library Filter
+
+### 3.1 Filter Sheet 字段
+
+- Resource Type，多选。
+- Lifecycle：Active / Archived / Trash。
+- Availability。
+- Favorite。
+- Has Download。
+- Collection。
+- Tag。
+- Added Date。
+- Updated Date。
+- External Provider。
+- Metadata Source。
+
+### 3.2 交互
+
+选中的过滤条件在列表顶部以可删除 Chip 展示。
+
+`清空` 只清理过滤条件，不清搜索关键词。
+
+复杂筛选可“保存为 Smart View”（当该能力落地时）。
+
+---
+
+## 4. Resource 通用详情页
+
+专业类型详情页共享一个通用 Header。
+
+### 4.1 Header
+
+Compact：
+
+1. 大封面 / Hero Image。
+2. 标题。
+3. Original / Alternative Title 一行，可展开。
+4. 类型 + 年份等核心 Chip。
+5. Availability 状态。
+6. 主操作组。
+
+Desktop：封面在左 240–320dp，右侧信息区。
+
+### 4.2 主操作组
+
+根据类型动态出现：
+
+- `播放 / 继续观看`。
+- `阅读 / 继续阅读`。
+- `播放音乐`。
+- `打开文档`。
+- `查看图片`。
+
+通用次操作：
+
+- 收藏。
+- Collection。
+- 下载。
+- 分享。
+- More。
+
+主操作只有一个 Filled Button；其他使用 Tonal / Outlined / Icon。
+
+### 4.3 状态说明卡
+
+当 Resource 非立即可用时显示。
+
+#### Remote
+
+`内容位于远端存储，打开时将读取远端内容。`
+
+#### Restoring
+
+显示：
+
+- `正在从归档层恢复`。
+- Progress。
+- Background Task ID 的用户友好入口。
+- `完成后通知我` Switch（若通知系统支持）。
+
+#### Missing
+
+显示缺失说明，不展示“重试播放”作为唯一动作。
+
+#### Corrupted
+
+使用 Error Container，提供`查看可用版本`、`报告问题`，普通用户不直接看到 Blob 管理动作。
+
+---
+
+## 5. Resource 详情 Tabs
+
+根据类型组合：
+
+- 概览。
+- 内容 / 剧集 / 章节 / 曲目。
+- 信息。
+- 关系。
+- 附件。
+- Activity。
+
+### 5.1 概览
+
+- Summary / Description。
+- 关键人员 / 作者。
+- Tag。
+- Collection。
+- Continue Progress。
+- Related Resource Preview。
+
+### 5.2 信息
+
+使用 Definition List，不使用一大段 JSON：
+
+- Resource ID（放高级信息）。
+- Type。
+- Created At。
+- Updated At。
+- Language。
+- Titles。
+- Lifecycle。
+- Metadata Provenance 摘要。
+
+### 5.3 附件
+
+普通用户只看到业务相关附件：
+
+- 封面。
+- 视频版本。
+- 字幕。
+- 电子书。
+- 图片。
+- 文档附件。
+
+每项：名称、类型、大小、Availability、Download 状态。
+
+不展示 Blob Placement 内部管理细节。
+
+---
+
+## 6. 多标题与语言
+
+在 Resource Detail 标题区域提供 `全部标题` 展开项。
+
+Side Sheet / Bottom Sheet 字段：
+
+- 标题文本。
+- Locale / Language。
+- Title Type：Original / Display / Alias / Romanized 等。
+- Source：Manual / Provider / Import。
+
+搜索命中别名时，Search Result 可提示：`匹配别名：xxx`。
+
+---
+
+## 7. Metadata Provenance
+
+### 7.1 入口
+
+详情 More → `元数据来源`。
+
+### 7.2 页面
+
+按字段显示：
+
+| 字段 | 当前值 | 来源 | 状态 |
+|---|---|---|---|
+| 标题 | ... | 用户手动 | 已锁定 |
+| 简介 | ... | Provider | 自动管理 |
+| 年份 | ... | 文件扫描 | 自动管理 |
+
+### 7.3 冲突
+
+字段有外部新值但用户已人工修改时：
+
+- 当前值卡。
+- 外部建议值卡。
+- 来源 Provider。
+- `保留我的值`。
+- `采用外部值`。
+- `恢复自动同步`。
+
+批量采用前必须预览变化。
+
+---
+
+## 8. External Identity
+
+详情 More → `外部身份`。
+
+每项：
+
+- Provider 图标与名称。
+- Namespace。
+- External ID。
+- 可选外部链接。
+- 最近同步。
+
+普通 App 可以查看和轻量修正自己有权限的映射；复杂 Provider 管理在 CMS。
+
+---
+
+## 9. Collection 列表
+
+### 9.1 页面布局
+
+顶部：Title + Create。
+
+分段：
+
+- Pin / Favorite Collections。
+- 最近使用。
+- 全部 Collection。
+
+Collection Card：
+
+- Cover Mosaic，最多 4 张缩略图。
+- Name。
+- Resource Count。
+- 手动 / 智能类型 Chip。
+- Updated At。
+- More。
+
+### 9.2 Create Collection
+
+Bottom Sheet / Dialog：
+
+- Name *。
+- Description。
+- Visibility。
+- Cover Strategy：自动 / 自定义。
+- `创建`。
+
+智能 Collection 的 Query Builder 放 Advanced，Mobile 不在首屏暴露复杂表达式。
+
+---
+
+## 10. Collection 详情
+
+### 10.1 Header
+
+- Cover / Mosaic。
+- Name。
+- Description。
+- Resource Count。
+- Owner / Shared 状态。
+- `添加资源`。
+- Share。
+- More。
+
+### 10.2 Content
+
+使用同 Library Card。支持：
+
+- 排序。
+- 筛选。
+- 多选。
+- 用户自定义顺序（手动集合）。
+
+Desktop 拖拽排序；Mobile 使用“编辑顺序”页上下拖动 Handle，避免普通浏览误拖。
+
+---
+
+## 11. 标签浏览
+
+标签页：
+
+- Search Tag。
+- 常用标签 Chips。
+- 全部标签 List。
+
+每行：Tag Name、Resource Count、可选颜色 / Icon。
+
+Tap 进入 Tag Result Page，使用 Library Grid。
+
+系统标签与用户标签在视觉上使用不同 Icon，并有说明。
+
+---
+
+## 12. Relation
+
+Resource Detail 的“关系”使用按 Relation Type 分组的卡片：
+
+例如：
+
+- Episode Of。
+- Sequel / Prequel。
+- Adaptation。
+- Related To。
+- Derived From。
+
+每组默认只显示前 6 项，`查看全部`。
+
+关系是双向导航，但 UI 必须显示关系方向，例如：
+
+```text
+本资源 --EPISODE_OF--> 某作品
+```
+
+不能只写“相关”。
+
+---
+
+## 13. 生命周期操作
+
+More → `管理`。
+
+普通用户有权限时提供：
+
+- Archive。
+- Restore from Archive。
+- Move to Trash。
+- Restore from Trash。
+
+`Permanently Delete` 只有明确权限时显示，并使用高风险 Dialog；说明永久删除 Resource 与底层 Blob GC 不等价，最终内容回收由服务端规则决定。
+
+---
+
+## 14. 批量选择
+
+Library 长按 / Desktop Checkbox 进入 Selection Mode：
+
+顶部 Action Bar：
+
+- 已选数量。
+- 收藏。
+- 加入 Collection。
+- 标签。
+- 下载。
+- 更多。
+
+删除不放在第一排，进入 More 后二次确认。
+
+---
+
+## 15. 响应式
+
+- Compact：2–3 列海报网格，视卡片最小宽度动态决定，不硬编码固定 3 列。
+- Medium：3–5 列。
+- Expanded：4–7 列，最大卡宽约 220dp。
+- Large：内容区域限制最大宽度，避免无限增加列数。
+- Detail >=840dp 可使用 Header + 右侧 Context Panel；Compact 全部纵向。

--- a/docs/v2/app-interaction/music/music-library-player.md
+++ b/docs/v2/app-interaction/music/music-library-player.md
@@ -1,0 +1,260 @@
+# Music：音乐库、队列与播放器
+
+## 1. 页面目录
+
+- 音乐首页。
+- Artist 列表 / 详情。
+- Album 列表 / 详情。
+- Track 列表。
+- Playlist / Collection。
+- Now Playing。
+- Queue。
+- Lyrics。
+- Together Room。
+
+---
+
+## 2. 音乐首页
+
+从上到下：
+
+1. Continue / Recently Played。
+2. Quick Mix：收藏、最近添加、随机播放。
+3. 最近专辑。
+4. 常听 Artist。
+5. Playlist / Music Collection。
+6. 下载的音乐。
+
+Music 首页进入后 Mini Player 持续存在（有活跃播放时）。
+
+---
+
+## 3. Artist 列表
+
+### Grid
+
+Artist Avatar / Cover、Name、Album Count。
+
+### Detail
+
+Header：Artist Image、Name、Alternative Name、`播放热门`、`随机播放`、Favorite。
+
+区块：
+
+- Popular Tracks。
+- Albums。
+- Related Resources。
+- Info。
+
+---
+
+## 4. Album 列表与详情
+
+### Album Card
+
+- 1:1 Cover。
+- Album Title。
+- Artist。
+- Year。
+- Downloaded / Remote 状态。
+
+### Album Detail Header
+
+- 1:1 Cover。
+- Title。
+- Artist Link。
+- Year / Type。
+- Track Count / Duration。
+- `播放`。
+- `随机`。
+- Download。
+- Favorite。
+- More。
+
+### Track Row
+
+- Index。
+- Title。
+- Artist（合集时）。
+- Duration。
+- Favorite。
+- Download State。
+- More。
+
+当前播放 Track 使用 Playing Indicator，不仅靠颜色。
+
+---
+
+## 5. Track More
+
+- 下一首播放。
+- 添加到队列末尾。
+- 添加到 Playlist / Collection。
+- 收藏。
+- 下载。
+- 查看专辑。
+- 查看 Artist。
+- 分享。
+- 查看信息。
+
+---
+
+## 6. Now Playing
+
+### 6.1 Compact
+
+竖向布局：
+
+1. Top Bar：Down / Back、播放设备、More。
+2. 大封面，宽约屏幕 72–84%。
+3. Title。
+4. Artist。
+5. Favorite。
+6. Progress Slider。
+7. Current / Duration。
+8. Previous / Play-Pause / Next。
+9. Shuffle / Repeat。
+10. Lyrics / Queue / Room 快捷按钮。
+
+### 6.2 Desktop
+
+两列：
+
+- 左：Cover + Track Info + Controls。
+- 右：Lyrics 或 Queue，可 Tab 切换。
+
+窗口很宽时不无限放大 Cover，建议最大 520dp。
+
+---
+
+## 7. Progress
+
+- Slider 支持 Scrub。
+- 支持 Buffered 状态（流媒体）。
+- Seek 后本地立即更新；服务端 Activity / Progress 节流同步。
+- 播放历史不要求每秒写服务端。
+
+---
+
+## 8. Shuffle / Repeat
+
+Repeat 三态：Off / Queue / One。
+
+Shuffle 开关必须保持 Queue 可解释：打开后展示实际播放顺序，关闭后恢复基准队列语义由播放器层定义。
+
+---
+
+## 9. Queue 页 / Sheet
+
+### Header
+
+- `播放队列`。
+- 当前 Queue Source，例如“专辑：xxx”。
+- Clear（不清除正在播放项前需确认产品行为）。
+
+### Item
+
+- Drag Handle。
+- Cover 40dp。
+- Title / Artist。
+- Duration。
+- More。
+
+Desktop 支持 Drag Reorder；Mobile 长按 Handle 后拖动。
+
+Swipe Delete 支持 Undo。
+
+---
+
+## 10. Lyrics
+
+- 当前句高亮并自动滚动。
+- 用户手动滚动后暂停自动跟随，出现 `回到当前歌词` Floating Button。
+- 支持时间轴歌词与纯文本歌词。
+- Translation / Romanization 若存在，使用次级文本。
+
+歌词不可用：显示 Empty + `查看歌曲信息`，不使用无限 Loading。
+
+---
+
+## 11. Playlist / Music Collection
+
+列表：Cover Mosaic、Name、Track Count、Duration、Owner / Shared。
+
+详情：
+
+- Play。
+- Shuffle。
+- Download。
+- Share。
+- Edit Order。
+
+音乐 Playlist 可以复用 Collection 底层能力，但 UI 使用音乐语义。
+
+---
+
+## 12. Download
+
+Album / Playlist 下载前 Bottom Sheet：
+
+- Track 数量。
+- Estimated Size。
+- Quality / Version（多个音源时）。
+- 当前设备剩余空间。
+- `下载`。
+
+下载中 Album Header 显示总进度，单 Track 显示独立状态。
+
+---
+
+## 13. Together Listening Room
+
+Now Playing → Room：
+
+- 创建 / 加入。
+- 同步 Track、Progress、Play/Pause、Queue。
+- Room Panel 展示成员、Queue、Chat。
+
+成员无目标 Track 访问权限时显示权限错误，不由 Room 转发媒体文件绕过 ACL。
+
+---
+
+## 14. Audio Session 与系统集成
+
+客户端应映射平台能力：
+
+- Background Playback。
+- Media Notification / Lock Screen Controls。
+- Headset Play/Pause。
+- OS Media Session。
+
+系统控制触发与 App 内控制使用同一 Player State。
+
+---
+
+## 15. Offline
+
+- 已下载 Track 优先本地播放。
+- 本地下载不存在但 Cache 有效时可命中缓存。
+- Cache 不显示为“已下载”。
+- Offline Queue 中 Remote-only Track 在到达时明确提示并允许跳过。
+
+---
+
+## 16. 错误状态
+
+- Attachment Missing：选择其他音源。
+- Network：重试 / 使用本地。
+- Decode：报告不支持格式 / 选择派生版本。
+- Permission：返回资源详情。
+
+播放错误只跳过当前 Track需用户设置允许，默认暂停并解释。
+
+---
+
+## 17. 响应式
+
+- Compact：Now Playing 全屏；Queue / Lyrics 用 Bottom Sheet / 独立页。
+- Medium：Now Playing + Bottom Tabs。
+- Expanded：左右双栏，Lyrics / Queue 常驻。
+- Mini Player 在所有非沉浸页保持一致状态。

--- a/docs/v2/app-interaction/notifications/notification-center.md
+++ b/docs/v2/app-interaction/notifications/notification-center.md
@@ -1,0 +1,238 @@
+# Notifications：通知中心与用户通知偏好
+
+## 1. 页面目录
+
+- 通知中心。
+- Notification Detail。
+- Notification Group / Digest。
+- 用户通知偏好。
+- Quiet Hours。
+
+管理员公告、模板、Provider 和系统级投递治理在 CMS；App 负责用户接收、阅读和偏好。
+
+---
+
+## 2. 通知中心
+
+### 2.1 App Bar
+
+- 标题 `通知`。
+- 未读数量 Badge。
+- Search（通知量大时）。
+- More：全部已读、Archived、通知设置。
+
+### 2.2 Tabs
+
+- 全部。
+- 未读。
+- 重要。
+- 已归档。
+
+### 2.3 Filter Chips
+
+- Content。
+- Planning。
+- Finance。
+- Security。
+- Storage / Download。
+- Automation / Sync。
+- Collaboration。
+- AI。
+
+---
+
+## 3. Notification Row
+
+从左到右：
+
+- Source Icon。
+- Unread Dot。
+- Title。
+- Body Preview，最多 2 行。
+- Time。
+- Priority Icon（High 时）。
+- More。
+
+下方可有最多两个 Inline Action，例如：
+
+- `查看`。
+- `重试`。
+- `批准 / 拒绝`（安全流程必须跳详情，不在列表直接执行高风险批准）。
+
+Tap 整行：Mark Read + Deep Link Target。
+
+---
+
+## 4. Source 与视觉
+
+Notification 必须显示来源，例如：
+
+- Media。
+- Planning。
+- Finance。
+- Security。
+- Backup / Storage。
+- Plugin。
+- Automation。
+- Room。
+
+Severity / Priority 使用 Icon + Label，不只用颜色。
+
+Security 高风险通知可使用 Warning Container，但不允许插件随意伪装 Security Source。
+
+---
+
+## 5. Notification Detail
+
+字段：
+
+- Source。
+- Title。
+- Full Body。
+- Created At。
+- Priority / Severity。
+- Related Object Card。
+- Actions。
+- Delivery Info（用户需要时折叠）。
+
+Related Object Card 点击跳 Resource / Task / Session / Rule / Room 等。
+
+---
+
+## 6. 敏感通知脱敏
+
+默认禁止锁屏 / 通知正文暴露：
+
+- Password / Token / TOTP。
+- Private Note Title / Body（除非用户显式允许安全摘要）。
+- 完整银行卡号 / PIN。
+- OTP Code。
+
+Private Reminder 默认：`私密提醒已到期`。
+
+Security OTP 本身不得通过普通 Notification Center 作为可回看的正文长期保存。
+
+---
+
+## 7. Swipe / Quick Actions
+
+Mobile：
+
+- 右滑：Mark Read / Unread。
+- 左滑：Archive。
+
+均支持 Snackbar Undo。
+
+不提供 Swipe Delete 作为默认动作，避免误删重要通知。
+
+Desktop Hover 显示 Read / Archive 图标。
+
+---
+
+## 8. 批量操作
+
+进入 Selection Mode：
+
+- Mark Read。
+- Mark Unread。
+- Archive。
+
+`全部已读` Dialog 显示当前筛选范围，例如“将 38 条未读通知标记为已读”。
+
+---
+
+## 9. Notification Group / Digest
+
+高频低优先级通知可以聚合：
+
+例如：
+
+```text
+元数据同步更新了 18 个资源
+2 个字段因人工锁定而保留
+```
+
+Group Card：Source、Summary、Item Count、Time Range、Expand。
+
+展开后显示原始通知，不用 Digest 取代原始记录。
+
+AI Digest 开启时明确 `AI 摘要`，并可查看原始通知。
+
+---
+
+## 10. Notification Preferences
+
+### 10.1 Channel
+
+按通知类别设置：
+
+- In-app。
+- Push。
+- Email。
+- Plugin Channel（用户可选时）。
+
+每行：Category、各 Channel Toggle。
+
+系统安全强制通知如果不能完全关闭，Toggle Disabled 并解释原因。
+
+### 10.2 Category
+
+至少：
+
+- Content Update。
+- Planning Reminder。
+- Finance Bill / Budget。
+- Download / Restore。
+- Sync / Import。
+- Collaboration / Room。
+- Security。
+- AI Job / Digest。
+
+---
+
+## 11. Quiet Hours
+
+字段：
+
+- Enabled。
+- Start Time。
+- End Time。
+- Days of Week。
+- Allow High Priority Override。
+- Allow Security Override（受系统策略）。
+
+跨午夜示例 `22:00–07:00` 正确显示。
+
+Quiet Hours 影响投递，不把通知本身删除。
+
+---
+
+## 12. Deep Link
+
+点击通知时：
+
+1. Mark Read。
+2. 解析 Target。
+3. 校验当前 Server。
+4. 校验权限 / Secure Unlock。
+5. 打开目标。
+
+Private Note 通知：先 Unlock，再目标 Note；取消 Unlock 返回 Notification Center，不泄露 Note Title。
+
+---
+
+## 13. Offline
+
+- 已缓存通知可离线查看。
+- Mark Read / Archive 可作为 Pending Change。
+- Deep Link 到 Remote-only Resource 时显示 Offline State。
+- Room Invite 等实时对象离线显示“当前无法加入”。
+
+---
+
+## 14. 响应式
+
+- Compact：列表 → Detail 全屏。
+- Medium：列表 + Detail Side Sheet。
+- Expanded：左 420dp List、右 Detail。
+- Large：右侧 Detail 中 Related Object / Action 可固定，不增加通知正文行宽。

--- a/docs/v2/app-interaction/offline/downloads-cache-offline.md
+++ b/docs/v2/app-interaction/offline/downloads-cache-offline.md
@@ -1,0 +1,327 @@
+# Offline：我的下载、缓存、空间与离线同步
+
+## 1. 产品语义
+
+客户端必须清楚区分：
+
+```text
+Download
+= 用户明确要求长期离线可用、可管理的本地副本
+
+Cache
+= 客户端内部访问加速数据，可淘汰、可重建
+```
+
+存在 Cache 不等于 Download Complete；清理 Cache 不等于删除用户下载。
+
+---
+
+## 2. 页面目录
+
+- 我的下载。
+- 下载队列。
+- Download Detail。
+- 离线可用内容。
+- 本机空间。
+- Cache 设置。
+- Pending Sync。
+- Sync Conflict。
+- Secure Offline Data 状态。
+
+---
+
+## 3. 我的下载
+
+### 3.1 App Bar
+
+- 标题 `我的下载`。
+- Search。
+- Filter。
+- Select。
+- More：下载设置、空间管理。
+
+### 3.2 顶部 Storage Summary
+
+横向 Card：
+
+- Downloads `32.4 GB`。
+- Cache `8.1 GB`。
+- Secure Encrypted Data `1.2 GB`。
+- Device Free Space `74 GB`。
+
+点击进入本机空间页。
+
+### 3.3 Filter
+
+- All。
+- Video。
+- Music。
+- Reading。
+- Photo / Document。
+- Completed。
+- Downloading。
+- Failed。
+- Offline Ready。
+
+---
+
+## 4. Download Item
+
+字段：
+
+- Cover / Icon。
+- Resource Title。
+- Child Scope，例如 Season 1 / Chapter 1–20 / Album。
+- Version / Quality。
+- Downloaded Size / Total Size。
+- Progress。
+- Status。
+- Integrity State。
+- Updated At。
+- More。
+
+Status：Queued / Downloading / Paused / Completed / Failed / Verifying / Needs Repair。
+
+Completed 只有满足完整性与离线使用要求后才显示。
+
+---
+
+## 5. 下载队列
+
+顶部操作：Pause All / Resume All。
+
+每项：
+
+- Priority Drag Handle。
+- Title。
+- Current File / Chunk。
+- Speed。
+- Downloaded / Total。
+- ETA（可靠时才显示）。
+- Pause / Resume。
+- Cancel。
+
+ETA 不可靠时显示 `估算中`，不展示不断跳动的虚假精确秒数。
+
+Desktop 可多任务并行详情；Mobile 默认紧凑列表。
+
+---
+
+## 6. 发起下载
+
+Resource / Episode / Album / Book 点击 Download 打开 Sheet：
+
+1. Download Scope。
+2. Version / Quality。
+3. Included Attachments，例如 Subtitle / Lyrics / Preview。
+4. Estimated Size。
+5. Device Free Space。
+6. Network Policy：Wi‑Fi Only（Mobile）。
+7. `下载`。
+
+如果已有有效 Cache：显示 `可复用 1.3 GB 缓存`，但仍进行 Download 完整性校验。
+
+---
+
+## 7. Download Detail
+
+Sections：
+
+- Resource。
+- Download Scope。
+- Quality / Version。
+- Local Size。
+- Created / Completed At。
+- Integrity Status。
+- Included Attachments。
+- Offline Playback / Read Test（可选）。
+
+Actions：Open Offline、Repair、Change Quality（重新下载）、Delete Download。
+
+Delete Dialog：`删除下载副本不会删除服务器上的 Resource。缓存是否同时清理由下一步选择。`
+
+---
+
+## 8. 删除下载
+
+确认 Sheet：
+
+- 删除 Download `2.4 GB`。
+- 可选 `同时清理可复用缓存 600 MB`。
+- Server Data：`不受影响`。
+- `删除本机副本`。
+
+Secure Domain 下载按 Secure Data 规则加密删除，不与普通 Cache 合并处理。
+
+---
+
+## 9. Cache 页面
+
+### 9.1 Summary
+
+- Total Cache Size。
+- Video Cache。
+- Audio Cache。
+- Image Preview Cache。
+- Document Cache。
+- AI Artifact Cache（如有）。
+
+### 9.2 Actions
+
+- Clear All Cache。
+- Clear by Type。
+- Set Max Size。
+- Auto Cleanup Policy。
+
+每项说明：`缓存可重建；清理不会删除“我的下载”。`
+
+### 9.3 Clear Cache
+
+无需极高风险验证，但 Dialog 显示：
+
+- Will Free X GB。
+- 可能导致下次打开重新联网下载。
+- Downloads 不受影响。
+
+---
+
+## 10. 离线可用内容
+
+不同于“我的下载”，该页聚合：
+
+- Completed Downloads。
+- Secure Vault 已同步加密本地数据（锁定后只显示安全摘要）。
+- 允许完整离线读取的 Pin 文档。
+
+普通临时 Cache 若不能保证完整消费，不列入 `离线可用`。
+
+Card 上显示 `离线可用` + 内容范围。
+
+---
+
+## 11. Offline Mode
+
+断网进入主 App：
+
+### 全局
+
+顶部 Offline Banner。
+
+### Navigation
+
+在线专属页面不消失，但进入后显示 Offline State + 可用缓存，不让用户误以为功能被删除。
+
+### 写操作
+
+支持离线的业务写入 Local Pending Queue：
+
+- Task。
+- Habit。
+- Playback / Reading Progress。
+- 普通文档编辑。
+- Finance Transaction。
+- Private Notes / Password Vault Ciphertext Change。
+
+不支持离线的高风险操作直接 Disabled + 原因。
+
+---
+
+## 12. Pending Sync 页面
+
+入口：Offline Banner / 我的下载页面 More / 我的设置。
+
+Group by Subsystem：
+
+- Planning。
+- Documents。
+- Finance。
+- Media Progress。
+- Private Notes。
+- Password Vault。
+
+每项：Object Safe Title、Change Type、Occurred At、Status、Retry Count、Error。
+
+Secure Domain 未解锁时不显示解密标题，只显示 `私密笔记变更`。
+
+Actions：Retry、Open Object、Discard Local Change（高影响时确认）。
+
+---
+
+## 13. Sync Conflict
+
+页面统一列出需要用户处理的跨端冲突，但实际 Resolver 跳对应子系统：
+
+- Document Conflict → Document Resolver。
+- Private Note → Secure Resolver。
+- Vault Item → Password Resolver。
+- Finance → Finance Conflict Flow。
+
+Global Conflict Card 只显示安全摘要与 `处理`。
+
+---
+
+## 14. Download 网络策略
+
+Settings：
+
+- Wi‑Fi Only。
+- Allow Cellular。
+- Ask for Files > N MB / GB。
+- Max Concurrent Downloads。
+- Background Download（平台支持）。
+- Battery Saver Behavior。
+
+切换到 Cellular 时如果存在大下载，弹一次非阻断确认。
+
+---
+
+## 15. 自动下载
+
+可选用户规则：
+
+- Favorite Anime New Episode。
+- Playlist New Track。
+- Book New Chapter。
+
+自动下载本质上可通过 Automation / Download Policy 实现；设置页显示关联 Rule，并允许跳转 Automation Detail。
+
+空间不足时暂停并通知，不自动删除显式 Download 来腾空间，除非用户明确配置保留策略。
+
+---
+
+## 16. Secure Offline Data
+
+Private Notes / Password Manager：
+
+- 本地只显示 Encrypted Cache Size。
+- `清除本机加密副本` 需要 Vault Locked / Confirm。
+- 清除前说明：若服务器不可达，之后无法离线访问，直到重新同步。
+- 清除不是删除服务端 Vault。
+
+已解锁状态下清除本机数据需要先安全锁定并关闭相关 Viewer。
+
+---
+
+## 17. 空间不足
+
+下载前检测 Free Space。
+
+不足时 Sheet：
+
+- Required。
+- Free。
+- Difference。
+- `管理空间`。
+- `降低质量`（适用时）。
+- Cancel。
+
+不自动清 Cache / Downloads 后直接开始。
+
+---
+
+## 18. 响应式
+
+- Compact：Download Card 列表；空间页面竖向卡。
+- Medium：左 Downloads / 右 Detail。
+- Expanded：Data Table + Detail Pane；Storage Summary 4 卡一行。
+- Large：Queue / Network Stats 可并排，Progress 列保持固定宽度。

--- a/docs/v2/app-interaction/password-manager/password-manager.md
+++ b/docs/v2/app-interaction/password-manager/password-manager.md
@@ -1,0 +1,555 @@
+# Password Manager：密码保险库与 Secret 管理
+
+## 1. 安全前提
+
+Password Manager 默认且必须使用 `USER_LOCKED_E2EE`。
+
+核心 UI 约束：
+
+- Ikaros Login ≠ Password Vault Unlock。
+- 服务端管理员不天然拥有解密权限。
+- Secret 默认隐藏。
+- “使用 Secret”优先于“展示 Secret”。
+- 本地离线缓存必须加密。
+- Copy / Reveal / Export 必须具备独立安全反馈。
+- Vault 锁定后立即移除所有解密内容。
+
+---
+
+## 2. 页面目录
+
+- Vault 列表。
+- Vault Unlock。
+- Vault Home。
+- Search / Folder / Collection。
+- Vault Item 详情。
+- Login Item。
+- Secure Note Item。
+- Card Item。
+- Identity Item。
+- TOTP。
+- Passkey。
+- SSH Key。
+- API Credential。
+- Custom Secret。
+- Password / Passphrase Generator。
+- Vault Health。
+- Shared Vault。
+- Conflict / Password History。
+- Emergency Access。
+- Export / Recovery。
+- Device / Biometric Settings。
+
+---
+
+## 3. Vault 列表与解锁
+
+### 3.1 Vault Card
+
+Locked 状态只显示安全允许的信息：
+
+- Vault Safe Name / Alias。
+- Personal / Shared / High-security 类型。
+- Lock Icon。
+- Local Encrypted Cache 状态。
+- Last Sync。
+- Conflict Count。
+- `解锁`。
+
+不显示 Item Title、URI、用户名等业务内容。
+
+### 3.2 Unlock 页面
+
+- Vault Name。
+- Lock Icon。
+- Unlock Method。
+- 主解锁输入 / 动作。
+- `使用生物识别`（已配置时）。
+- `无法解锁？`。
+
+生物识别只保护本地解锁密钥，不上传生物数据。
+
+---
+
+## 4. Vault Home
+
+### 4.1 App Bar
+
+- Vault Name。
+- Lock Now。
+- Search。
+- Add Item。
+- More。
+
+### 4.2 顶部 Quick Filter
+
+Chips：
+
+- 全部。
+- 收藏。
+- Login。
+- Card。
+- Identity。
+- TOTP。
+- Passkey。
+- SSH / API。
+
+### 4.3 Item Row
+
+- Item Type Icon。
+- Name。
+- Username / Safe Secondary Label（根据类型）。
+- Favorite。
+- Folder / Collection。
+- TOTP Indicator（存在时）。
+- Attachment Indicator。
+- Conflict / Pending Sync。
+- More。
+
+密码、完整卡号、TOTP Seed、Private Key 不出现在列表摘要。
+
+---
+
+## 5. Search
+
+Vault 解锁后本地搜索：
+
+- Name。
+- Username。
+- URI / Origin。
+- Folder。
+- 非隐藏 Custom Field（策略允许）。
+
+默认不搜索 Hidden Secret Value。
+
+Search Query 不进入普通 App 全局搜索历史。
+
+锁定后 Search UI 和 Result 立即销毁。
+
+---
+
+## 6. Add Item
+
+Bottom Sheet：
+
+- Login。
+- Secure Note。
+- Card。
+- Identity。
+- TOTP。
+- Passkey（平台能力允许时）。
+- SSH Key。
+- API Credential。
+- Custom Secret。
+
+选择后进入对应 Editor。
+
+---
+
+## 7. Login Item 详情
+
+### 7.1 Header
+
+- Site / Service Icon。
+- Item Name。
+- Favorite。
+- Edit。
+- More。
+
+### 7.2 字段顺序
+
+1. Username。
+   - 右侧 Copy。
+2. Password。
+   - 默认 `••••••••`。
+   - Reveal。
+   - Copy。
+   - Password History。
+3. URI / Origin 列表。
+   - URI。
+   - Match Policy。
+   - Open Link。
+4. TOTP Reference。
+   - 当前 Code（若已解锁）。
+   - 倒计时环。
+   - Copy。
+5. Notes。
+6. Custom Fields。
+7. Attachments。
+8. Updated At / Revision。
+
+### 7.3 Reveal Password
+
+Tap Reveal：
+
+- 已满足 Vault Unlock 且策略允许：短暂显示。
+- 需要 Fresh Verification：先 Step-up。
+- 显示后提供 `隐藏`。
+- 页面离开 / App 后台自动隐藏。
+
+不要在 Reveal 后把明文写入普通状态日志。
+
+### 7.4 Copy Password
+
+复制后 Snackbar：`已复制，30 秒后尝试清除剪贴板`。
+
+倒计时时长由本机安全设置决定。
+
+平台无法可靠清理剪贴板时，文案不能承诺“必定删除”。
+
+---
+
+## 8. Login Item 编辑
+
+字段：
+
+- Name *。
+- Username。
+- Password。
+- URI，可多条。
+- 每条 URI Match Policy：Exact Origin / Host / Base Domain / Starts With / Advanced Regex / Never Autofill。
+- TOTP Reference。
+- Folder。
+- Collection / Shared Vault Scope。
+- Notes。
+- Custom Fields。
+- Attachments。
+
+Password Field 右侧：`生成`。
+
+保存前 URI 与 Match Policy 显示 phishing 风险提示；可疑宽松规则需要明确确认。
+
+---
+
+## 9. Phishing Protection UI
+
+当 Autofill / 使用密码目标不匹配：
+
+Warning Sheet：
+
+```text
+已保存：example.com
+当前：examp1e.com
+```
+
+显示：
+
+- Origin 差异。
+- Match Policy。
+- `取消` 主推荐。
+- `仍然使用` 需要二次确认 / Step-up（策略决定）。
+
+默认不静默填充。
+
+---
+
+## 10. Card Item
+
+### 10.1 默认展示
+
+- Card Name。
+- Cardholder。
+- Card Number：`•••• •••• •••• 1234`。
+- Expiration：可显示。
+- Security Code：`•••`。
+- Billing Metadata。
+- Notes。
+
+### 10.2 Reveal
+
+完整 Card Number / CVC 分别拥有 Reveal，不因显示卡号自动显示 CVC。
+
+PIN 作为独立高敏感 Secret Field，放 `更多安全字段` 中。
+
+Copy 后应用剪贴板安全策略。
+
+---
+
+## 11. Identity Item
+
+字段：
+
+- Name。
+- Address。
+- Email。
+- Phone。
+- Identification Metadata。
+- Custom Fields。
+
+身份证件号码等高敏感字段默认 Masked / Hidden。
+
+用于 Autofill 时显示目标应用 / Origin 与将填写的字段预览。
+
+---
+
+## 12. TOTP
+
+### 12.1 TOTP Item
+
+- Service Name。
+- Account。
+- 6 / 8 Digit Code。
+- Circular Period Progress。
+- Copy。
+- Linked Login。
+
+Seed 默认永不显示。
+
+### 12.2 添加
+
+- Scan QR。
+- Import `otpauth://`。
+- Manual。
+
+Manual Advanced：Secret、Period、Digits、Algorithm。
+
+保存前提供测试 Code Preview。
+
+---
+
+## 13. Passkey
+
+Item 详情只显示安全元信息：
+
+- RP / Site。
+- Account / User Handle Display。
+- Created At。
+- Last Used At。
+- Device / Sync Metadata（可用时）。
+
+Private Key Material 无普通 Reveal 按钮。
+
+使用 Passkey 通过 OS Credential API / WebAuthn 集成，不导出原始私钥作为常规交互。
+
+---
+
+## 14. SSH Key
+
+字段：
+
+- Name。
+- Algorithm。
+- Fingerprint。
+- Public Key。
+- Private Key Hidden。
+- Comment。
+- Optional Passphrase Hidden。
+
+主动作优先：`使用密钥` / `复制公钥`。
+
+`导出私钥` 属于高风险动作，Step-up + 明确目标位置 + Audit。
+
+---
+
+## 15. API Credential
+
+字段：
+
+- Name。
+- Endpoint。
+- Client ID。
+- API Key / Token Hidden。
+- Client Secret Hidden。
+- Expiration。
+- Scope。
+- Related Integration。
+
+若被其他 Ikaros 子系统通过 `secret://` 引用，详情显示：`被 3 个集成使用`，点击查看引用对象（权限允许时）。
+
+---
+
+## 16. Custom Secret
+
+用户可添加字段：
+
+- Text。
+- Hidden。
+- Boolean。
+- Linked Secret。
+
+Hidden Field 默认：
+
+- UI Mask。
+- 不进入普通搜索。
+- 不进入 AI。
+- Copy 后清理策略。
+
+---
+
+## 17. Password Generator
+
+### 17.1 Password Tab
+
+字段：
+
+- Length Slider + 数字输入。
+- Uppercase。
+- Lowercase。
+- Numbers。
+- Symbols。
+- Avoid Ambiguous。
+- Minimum Numbers。
+- Minimum Symbols。
+
+顶部大号 Generated Password + Regenerate + Copy。
+
+### 17.2 Passphrase Tab
+
+- Word Count。
+- Separator。
+- Capitalization。
+- Number Suffix。
+
+### 17.3 Username Tab
+
+支持随机 Username 规则（能力落地时）。
+
+生成器可独立使用，不要求保存到 Vault。
+
+---
+
+## 18. Password History
+
+Item Detail → History。
+
+列表只显示：
+
+- Changed At。
+- Revision。
+- Device / Actor。
+- Hidden Password。
+
+点击 Reveal Historical Password 仍需安全策略。
+
+Retention：Off / Last N / N Days。
+
+---
+
+## 19. Conflict Resolver
+
+两个设备同时编辑 Item 时：
+
+- 显示 Mine / Remote Version Metadata。
+- 不直接并排显示所有 Secret 明文。
+- 字段级比较时 Hidden Field 默认遮罩，逐字段 Reveal。
+
+操作：Keep Mine / Keep Remote / Keep Both / Manual Merge。
+
+Password History 保留冲突前值。
+
+---
+
+## 20. Vault Health
+
+### 20.1 Dashboard
+
+Cards：
+
+- Weak Password。
+- Reused Password。
+- Old Password。
+- Missing 2FA Metadata。
+- Insecure HTTP URI。
+- Duplicate Item。
+- Optional Breach Check。
+
+每卡：Count + `查看`。
+
+### 20.2 Detail
+
+只在本地解锁后显示 Item Name；不把完整 Password 上传用于分析。
+
+Breach Check 若使用外部 Provider，设置页解释隐私保护查询方式与开关。
+
+---
+
+## 21. Shared Vault / Collection
+
+列表显示：Name、Members、Role、Last Sync。
+
+Member Detail 权限：Owner / Manager / Editor / Viewer，以及细粒度：Reveal Secret / Autofill / Edit / Share / Export。
+
+共享变更必须清楚说明 Key / Access 影响，移除成员不是简单隐藏菜单。
+
+---
+
+## 22. Emergency Access
+
+页面显示：
+
+- Trusted Contact。
+- Access Scope。
+- Waiting Period。
+- Status。
+- Last Request。
+
+收到请求时 Notification 进入 Emergency Request Detail：Approve / Reject。
+
+Waiting Period 未结束时显示倒计时；Owner 可 Reject。
+
+管理员没有默认 Emergency Access 后门。
+
+---
+
+## 23. Export
+
+首选 Encrypted Vault Export。
+
+明文 / CSV / JSON Export 需要：
+
+- Scope Preview。
+- Item Count。
+- 是否包含 Attachments。
+- Fresh Verification。
+- 风险说明。
+- 目标位置。
+
+按钮文案：`导出未加密副本`。
+
+---
+
+## 24. Recovery
+
+页面明确：
+
+- Account Recovery ≠ Vault Recovery。
+- 当前 Security Profile。
+- Recovery Policy。
+- Recovery Key / Trusted Device 等可用方法。
+
+Zero-knowledge 无恢复材料时明确数据不可恢复风险。
+
+---
+
+## 25. Offline-first
+
+断网时支持：
+
+- Search。
+- Autofill。
+- TOTP。
+- Generator。
+- 查看 / 新建 / 修改 Item。
+
+全部基于 Encrypted Vault Cache。
+
+联网后同步 Ciphertext Delta；Conflict 不使用无提示 Last Write Wins。
+
+---
+
+## 26. App Switcher / Screenshot
+
+默认对 Password Manager 启用安全预览：
+
+- 切后台时隐藏 Item Detail。
+- 最近任务卡只显示 Lock Surface。
+- Screenshot 阻止作为本机选项，平台支持时开启。
+
+---
+
+## 27. 响应式
+
+- Compact：Vault List → Item List → Item Detail 分页。
+- Medium：Item List + Detail 双栏。
+- Expanded：Folder / Item List / Detail 三栏。
+- Large：Secret Detail 最大宽度约 760dp，避免敏感值跨超宽屏展示；右侧可放 References / History。

--- a/docs/v2/app-interaction/photos/photo-album.md
+++ b/docs/v2/app-interaction/photos/photo-album.md
@@ -1,0 +1,222 @@
+# Photos：图片与相册
+
+## 1. 页面目录
+
+- 图片首页 / 时间线。
+- Album 列表。
+- Album 详情。
+- Photo Viewer。
+- Photo Info。
+- 多选与批量操作。
+
+---
+
+## 2. 图片首页
+
+### 2.1 App Bar
+
+- 标题 `图片`。
+- Search。
+- Filter。
+- Select。
+
+### 2.2 视图切换
+
+- Timeline。
+- All Photos。
+- Albums。
+
+Timeline 默认按日期分组。
+
+### 2.3 日期 Group
+
+Header：
+
+- 日期，例如 `2026 年 8 月 30 日`。
+- 当天图片数量。
+- Select Group。
+
+Grid 使用接近正方形 Thumbnail，图片使用 `BoxFit.cover`；进入 Viewer 查看完整比例。
+
+---
+
+## 3. 图片 Grid
+
+### Item Overlay
+
+只在必要时显示：
+
+- Favorite。
+- Video / Live Photo 类型（未来支持时）。
+- Remote / Restoring 状态。
+- Selected Check。
+
+普通 Available 图片不堆叠状态文字。
+
+### 交互
+
+Tap：Viewer。
+
+Long Press：进入 Selection Mode 并选中当前图。
+
+Desktop Hover：右上角 Selection Checkbox 与 Quick Favorite。
+
+---
+
+## 4. Album 列表
+
+Album Card：
+
+- Cover。
+- Name。
+- Photo Count。
+- Date Range。
+- Shared 状态。
+
+支持：Create Album、Sort、Search。
+
+---
+
+## 5. Album Detail
+
+Header：
+
+- Cover / Hero。
+- Name。
+- Description。
+- Count。
+- Date Range。
+- Share。
+- Add Photos。
+- More。
+
+Content 使用 Photo Grid。
+
+手动 Album 支持 Edit Order；智能 Album 显示 Query 摘要，普通 App 只提供常见筛选编辑，高级表达式可转 CMS / Advanced 页面。
+
+---
+
+## 6. Photo Viewer
+
+### 6.1 Immersive
+
+黑 / 深色背景优先。
+
+Top Bar：Back、Date / Album、Favorite、Share、More。
+
+Bottom Bar：Previous / Next（Desktop 可隐去）、Info、Edit Metadata（有权限）、Download。
+
+### 6.2 手势
+
+- 左右 Swipe：上一张 / 下一张。
+- Pinch：Zoom。
+- Double Tap：Zoom Toggle。
+- Zoom 后单指拖动图片，不触发换图直到回到边界并达到阈值。
+
+Desktop：鼠标滚轮默认不换图；Arrow Key 换图。
+
+### 6.3 预加载
+
+预加载前后 1–2 张适配尺寸的 Preview，不在移动端无上限预拉原图。
+
+---
+
+## 7. Photo Info Sheet
+
+字段分组：
+
+### Basic
+
+- Title / Filename Display。
+- Date Taken。
+- Added At。
+- Dimensions。
+- File Size。
+- MIME / Format。
+
+### Camera / EXIF
+
+存在时显示：
+
+- Device / Camera。
+- Lens。
+- ISO。
+- Aperture。
+- Shutter。
+- Focal Length。
+
+### Location
+
+存在且用户有权限时：
+
+- Location Text。
+- Map Preview（未来可选）。
+
+### Organization
+
+- Albums / Collections。
+- Tags。
+- Related Resource。
+
+### Storage
+
+只显示用户语义：Available / Cached / Remote / Restoring、Downloaded；不直接展示底层 Object Key。
+
+---
+
+## 8. AI 能力
+
+图片 More / Selection Mode：
+
+- 生成描述。
+- OCR。
+- 建议标签。
+- 语义搜索。
+
+AI 处理属于 Job 时显示 Job Progress；生成标签先进入 Suggestion Preview，用户确认后写入。
+
+---
+
+## 9. 多选操作
+
+Action Bar：
+
+- Add to Album。
+- Favorite。
+- Download。
+- Share。
+- Tag。
+- More。
+
+More：Archive / Trash（有权限）。
+
+批量下载显示总数量与预计空间。
+
+---
+
+## 10. Original / Preview
+
+Viewer 默认选择适合屏幕的 Preview / Derived Attachment。
+
+提供 `查看原图`：
+
+- 原图 Remote 时提示网络与大小。
+- 原图 Archive 时触发 Restore Flow。
+- Preview 清理不等于删除原图。
+
+---
+
+## 11. Offline
+
+- 已下载原图 / Preview 可离线查看。
+- Cache 命中时显示内容但仍不标记 Downloaded。
+- Offline Selection 可修改 Favorite / Album 等允许同步的元数据，标记 Pending。
+
+---
+
+## 12. 响应式
+
+- Grid 根据最小 Thumbnail 120–180dp 自适应列数。
+- Compact Viewer 全屏。
+- Expanded Viewer 左侧图像 + 右侧可固定 Info Pane 320–360dp。
+- Large Timeline 不把 Thumbnail 放大到失去浏览密度，增加列数但设置最大列宽。

--- a/docs/v2/app-interaction/private-notes/private-notes.md
+++ b/docs/v2/app-interaction/private-notes/private-notes.md
@@ -1,0 +1,451 @@
+# Private Notes：私密笔记
+
+## 1. 安全前提
+
+Private Notes 是独立 Secure Domain，默认 `USER_LOCKED_E2EE`。
+
+必须遵守：
+
+- Ikaros Login ≠ Private Vault Unlock。
+- 服务端默认不可读取标题、正文、标签、Notebook 名称、附件文件名。
+- 本地持久缓存必须加密。
+- 普通全局 Search 不保存私密明文索引。
+- 普通 Activity / Notification 默认脱敏。
+- 锁定后立即清理解密 UI、搜索索引访问、剪贴板敏感内容与预览缓存。
+
+---
+
+## 2. 页面目录
+
+- Private Vault 列表。
+- Vault Unlock。
+- Notebook / Note 首页。
+- 本地搜索。
+- Private Note Viewer。
+- Private Note Editor。
+- Private Attachment Viewer。
+- Revision。
+- Sync Conflict。
+- Templates。
+- Secure Share。
+- Export。
+- Recovery。
+- Vault Settings。
+
+---
+
+## 3. Vault 列表
+
+### 3.1 页面布局
+
+App Bar：`私密笔记` + Add Vault（有能力时） + More。
+
+每个 Vault Card 在 Locked 状态只展示允许的最小元数据：
+
+- Vault Display Name：只有客户端拥有可解密本地元数据时显示；否则可显示用户自定义安全别名或 `私密保险库`。
+- Lock Icon。
+- Security Profile。
+- Local Encrypted Cache 状态。
+- Last Sync（可显示最小同步元数据时）。
+- Conflict Count，只显示数量，不泄露标题。
+- `解锁`。
+
+不显示 Note Title Preview。
+
+---
+
+## 4. Vault Unlock
+
+### 4.1 页面
+
+中心 Lock Icon。
+
+- Vault Name / Safe Alias。
+- `保险库已锁定`。
+- 解锁方法说明。
+- Primary Unlock Field / Action。
+- Biometric Button（本机已配置时）。
+- `无法解锁？`。
+
+### 4.2 生物识别
+
+点击使用系统 Biometric API 解开本地包装密钥；生物特征数据不上传 Ikaros。
+
+失败后仍可返回主解锁方式。
+
+### 4.3 成功
+
+- Key 只进入受控内存状态。
+- 构建 / 打开本地加密搜索索引。
+- 返回用户原来请求的 Note / Vault 页面。
+
+---
+
+## 5. Vault Home
+
+### 5.1 App Bar
+
+- Vault Name。
+- Lock Now 图标。
+- Search。
+- New Note。
+- More。
+
+### 5.2 Desktop Layout
+
+三栏：
+
+- 左 240dp Notebook Tree。
+- 中 320–420dp Note List。
+- 右 Note Viewer / Editor。
+
+### 5.3 Mobile Layout
+
+首页先显示：
+
+1. Search Bar。
+2. Pinned / Recent Notes。
+3. Notebook 列表。
+4. Tag 横向 Chip。
+5. Recent Modified。
+
+点 Note 进入全屏 Viewer。
+
+---
+
+## 6. Notebook Tree
+
+每个节点：
+
+- Folder Icon。
+- Notebook Name（仅解锁后）。
+- Note Count。
+- Expand Chevron。
+- More。
+
+支持层级。
+
+操作：New Note、New Sub-notebook、Rename、Move、Export Notebook（高风险）、Delete。
+
+Notebook 名称本身属于加密数据，锁定后整个 Tree 消失，不残留最近名称。
+
+---
+
+## 7. Note List
+
+每个 Row：
+
+- Title。
+- 2 行 Body Preview（用户设置允许时）。
+- Tags。
+- Updated At。
+- Attachment Icon。
+- Pending Sync / Conflict 状态。
+- Pinned。
+
+用户可在 Vault Settings 关闭正文 Preview；关闭后只显示 Title + Metadata。
+
+---
+
+## 8. 本地搜索
+
+### 8.1 入口
+
+Vault 解锁后 Search。
+
+### 8.2 搜索域
+
+- Title。
+- Body。
+- Tag。
+- Notebook。
+- Attachment OCR Text（本地 OCR 可用时）。
+
+搜索使用解锁后的本地索引。
+
+### 8.3 锁定
+
+搜索页立即关闭；查询词从输入历史中清除，不进入普通全局 Search History。
+
+---
+
+## 9. Private Note Viewer
+
+### 9.1 Top Bar
+
+- Back。
+- Title。
+- Lock Now。
+- Edit。
+- More。
+
+### 9.2 Metadata
+
+- Notebook。
+- Tags。
+- Updated At。
+- Revision。
+
+### 9.3 Body
+
+支持 Markdown / Rich Text / Checklist / Table / Code / Callout / Link / Image / Attachment / Document Link。
+
+Password Manager Secret Reference 渲染为：
+
+```text
+[Key] Bank Login Password   [使用/显示]
+```
+
+默认不把 Secret 明文直接嵌进 Note DOM / Widget Tree 的长期状态。
+
+### 9.4 普通 Resource Link
+
+可显示普通 Resource Card。
+
+关系默认 `PRIVATE_SIDE_ONLY`；普通 Resource Detail 不显示反向“有私密笔记”提示。
+
+---
+
+## 10. Editor
+
+### 10.1 布局
+
+复用普通 Document Editor 的编辑能力，但底部 / App Bar 必须显示 Secure 状态：`端到端加密`。
+
+字段：
+
+- Title。
+- Notebook。
+- Tags。
+- Body。
+- Attachments。
+
+### 10.2 Local Commit
+
+编辑过程：
+
+- Plaintext 只存在解锁内存。
+- 自动保存生成 Local Encrypted Commit。
+- Sync 上传 Ciphertext。
+- UI 状态：`本机已加密保存` / `正在同步密文` / `离线待同步`。
+
+不显示“正在把正文上传服务器”这类误导文本。
+
+---
+
+## 11. Private Attachment
+
+### 11.1 Attachment Row
+
+解锁后显示：
+
+- Decrypted Display Filename。
+- Type。
+- Size。
+- Local Encrypted Cache 状态。
+- Sync 状态。
+- More。
+
+### 11.2 Viewer
+
+使用流式解密；退出 Viewer 清理临时明文缓冲。
+
+不自动保存到公共 Downloads。
+
+### 11.3 导出明文附件
+
+动作流程：
+
+1. `导出明文`。
+2. Dialog 说明“导出后的文件离开 Ikaros 加密保护”。
+3. Fresh Unlock / Step-up（策略要求时）。
+4. 选择系统目标位置。
+5. 导出。
+6. Audit / Security Activity（按设计）。
+
+---
+
+## 12. Revision
+
+Revision List：Version、Time、Device / Author、Sync State。
+
+内容仅解锁后加载。
+
+操作：Preview、Compare、Restore。
+
+Restore 创建新 Revision，不清除原历史。
+
+Retention 设置：N Days / N Revisions / Manual Keep。
+
+---
+
+## 13. Sync Conflict
+
+### 13.1 Conflict Banner
+
+Note Row 与 Viewer 顶部显示：`存在同步冲突` + Resolve。
+
+### 13.2 Resolver
+
+显示：
+
+- Mine Revision 时间 / Device。
+- Remote Revision 时间 / Device。
+- Base Revision。
+
+操作：
+
+- Keep Mine。
+- Keep Remote。
+- Keep Both。
+- Manual Merge。
+
+### 13.3 Manual Merge
+
+Desktop 可三栏 Base / Mine / Remote + Result。
+
+Mobile 使用 Tabs，Result 独立编辑区。
+
+任何选项都不静默删除未选版本，直到新合并 Revision 安全提交。
+
+---
+
+## 14. Templates
+
+Template 列表也在 Vault 内解密：
+
+- Private Diary。
+- Emergency Information。
+- Medical Record。
+- Legal Notes。
+- Personal Profile。
+- Recovery Instructions。
+- 用户自定义。
+
+使用模板创建后生成独立 Note，不与模板保持强同步。
+
+---
+
+## 15. Secure Share
+
+Private Note 不使用普通匿名永久 Share Link。
+
+Create Share Sheet：
+
+- Recipient：指定 Ikaros User / One-time Secure Share。
+- Expiration。
+- Permission：View / Edit（能力支持时）。
+- Attachment Access。
+- Revoke Policy。
+
+确认页明确“共享会建立加密访问权限”。
+
+---
+
+## 16. AI Integration
+
+默认 AI Access：`DENY`。
+
+Vault Settings 可选：
+
+- Deny。
+- Local Only。
+- Cloud Per-use Confirmation（未来可选，必须明确 Provider 与发送范围）。
+
+Note 中 AI 按钮只有策略允许时出现。
+
+Local AI 支持：Summary、Classification、Writing Assist、OCR、Semantic Search。
+
+执行前 Context Preview 列出将解密给模型的 Note / Attachment 范围。
+
+---
+
+## 17. Reminder
+
+Private Reminder 创建字段：Date/Time、Repeat、Safe Summary Policy。
+
+系统通知默认内容：`私密提醒已到期`。
+
+用户若选择显示自定义摘要，UI 必须警告该摘要可能出现在锁屏通知。
+
+---
+
+## 18. Lock Behavior
+
+点击 `Lock Now` 或自动锁定：
+
+- 关闭 Note Viewer / Editor 的 Plaintext Widget。
+- 清空本地明文搜索 Session。
+- 清理敏感 Clipboard（平台允许时）。
+- 清理 Decrypted Attachment Preview。
+- Key Material 从内存移除。
+- 页面切换为 Locked Surface。
+
+未同步的本地编辑必须已经以加密形式落盘后才能完成锁定；若加密保存失败，先显示阻断式错误。
+
+---
+
+## 19. Screenshot / Recent Apps
+
+Vault Settings：
+
+- `隐藏最近任务预览` 默认 On。
+- `禁止截图` 可选，平台支持时。
+- `切到后台立即锁定`。
+
+启用后 App Switcher 预览使用纯色 + Ikaros Lock Logo，不显示正文。
+
+---
+
+## 20. Export
+
+优先：`Encrypted Ikaros Vault Export`。
+
+明文导出选项：Markdown / JSON / PDF（支持时）。
+
+明文导出页面必须显示：
+
+- 导出范围。
+- Note Count / Attachment Count。
+- 目标位置。
+- 安全风险。
+- Step-up Requirement。
+
+按钮文案使用 `导出未加密副本`，不使用模糊“导出”。
+
+---
+
+## 21. Recovery
+
+页面复用 Access 安全恢复流程，并在 Vault 上下文明确：
+
+- Security Profile。
+- Recovery Mode。
+- 可用 Recovery Method。
+- 是否存在无法恢复风险。
+
+Zero-knowledge 无 Recovery Key 时不提供虚假的管理员恢复入口。
+
+---
+
+## 22. Offline-first
+
+断网时仍支持：
+
+- 查看已同步的加密 Vault 内容。
+- 新建 / 编辑 / 删除 Note。
+- 本地搜索。
+- 添加本地 Attachment。
+- Revision。
+
+Sync 状态显示在 Note / Vault 层，不阻断本地使用。
+
+---
+
+## 23. 响应式
+
+- Compact：Vault Home / Note Viewer / Editor 分页进入。
+- Medium：Notebook + Note List 双栏，Viewer 覆盖 / Side Sheet。
+- Expanded：Notebook / List / Viewer 三栏。
+- Large：Editor 正文仍限制可读宽度；右侧可固定 Outline / Properties。
+- 所有宽度下 Lock 立即覆盖明文区域，不因 Desktop 多栏而残留 Preview。

--- a/docs/v2/app-interaction/productivity/productivity-planning.md
+++ b/docs/v2/app-interaction/productivity/productivity-planning.md
@@ -1,0 +1,558 @@
+# Productivity：效率与计划
+
+## 1. 页面目录
+
+- Today。
+- Inbox。
+- Upcoming。
+- Task 列表。
+- Task 详情 / 编辑。
+- Project 列表 / 详情。
+- Kanban。
+- Eisenhower Matrix。
+- Calendar。
+- Time Block 编辑。
+- Goal 列表 / 详情。
+- OKR Cycle / Objective / Key Result。
+- Milestone。
+- Habit。
+- Focus。
+- Daily / Weekly / Monthly / Quarterly Review。
+
+本子系统严格区分：Task、Calendar Event、Scheduled Time、Deadline、Time Block、Goal、Habit、Focus Session。
+
+---
+
+## 2. Today 页面
+
+### 2.1 App Bar
+
+- 标题 `今天` + 日期。
+- Calendar Icon。
+- `+` Quick Add。
+- More：Daily Planning、筛选、排序。
+
+### 2.2 顶部 Summary
+
+Compact 使用横向卡片：
+
+- Task：`3 / 7 已完成`。
+- Focus：`1h 20m`。
+- Habit：`2 / 4`。
+- Overdue：`2`。
+
+这些是事实摘要，不显示“效率分数”。
+
+### 2.3 时间线区域
+
+按时间顺序混合但视觉可区分：
+
+- Calendar Event。
+- Scheduled Task。
+- Time Block。
+- Habit Schedule。
+
+每种使用不同 Icon + Type Label。
+
+### 2.4 Unscheduled Today
+
+没有 Scheduled Time、但 Pin 到 Today / Deadline Today 的 Task 放单独区块。
+
+### 2.5 Overdue
+
+置于 Today 顶部或显眼 Warning Section，但不把 `Overdue` 当 Task Lifecycle Status。
+
+每项快速动作：完成、重新安排、打开详情。
+
+---
+
+## 3. Quick Add Task
+
+### 3.1 Compact Bottom Sheet
+
+第一屏只保留高频字段：
+
+- `标题 *`。
+- Today / Tomorrow / Date 快捷 Scheduled Time。
+- Deadline 图标。
+- Project。
+- Priority。
+- `创建`。
+
+点击 `更多` 展开完整字段。
+
+### 3.2 自然语言 AI
+
+AI 可用时提供 `用自然语言创建`：
+
+例如输入“下周三前完成数据库设计，预计4小时，拆三步”。
+
+AI 输出先生成 Draft Preview：Title、Scheduled、Deadline、Estimate、Subtasks；用户确认后创建。
+
+---
+
+## 4. Inbox
+
+### 4.1 目标
+
+快速 Capture，不要求先决定 Project / 时间 / Goal。
+
+### 4.2 Row
+
+- Checkbox / Status Icon。
+- Title。
+- Created At。
+- Optional Note Indicator。
+- More。
+
+### 4.3 Clarify Flow
+
+Tap Item 打开 Bottom Sheet：
+
+- 加入 Project。
+- Scheduled Time。
+- Deadline。
+- Priority。
+- Estimate。
+- Related Resource。
+- `保留在 Inbox` / `计划`。
+
+---
+
+## 5. Task 列表页
+
+### 5.1 顶部 View
+
+Tabs / Saved Views：
+
+- All。
+- Planned。
+- In Progress。
+- Completed。
+- Blocked。
+- Saved Smart Views。
+
+### 5.2 Task Row
+
+从左到右：
+
+- Completion Checkbox。
+- Title。
+- Status Chip（仅特殊状态，如 Blocked）。
+- Project / Section。
+- Scheduled Time。
+- Deadline。
+- Priority Flag。
+- Estimate。
+- Assignee Avatar（共享项目）。
+- Related Resource Icon。
+- More。
+
+Compact 只首行显示 Title，第二行组合 Project + Time；其余进入详情。
+
+### 5.3 Swipe / Mouse
+
+Mobile：
+
+- 右滑：Complete，必须 Snackbar Undo。
+- 左滑：Schedule / Snooze，可逆。
+
+Desktop：Hover 显示 Quick Actions；右键 Context Menu。
+
+---
+
+## 6. Task 详情 / 编辑
+
+### 6.1 Header
+
+- Completion Checkbox。
+- Title Editable。
+- Status。
+- More。
+
+### 6.2 字段顺序
+
+1. Description。
+2. Project。
+3. Section。
+4. Status。
+5. Priority。
+6. Important Switch。
+7. Urgent Switch。
+8. Scheduled Start。
+9. Scheduled End。
+10. Deadline。
+11. Estimated Duration。
+12. Actual Duration（只读汇总 + 手动补录入口）。
+13. Recurrence。
+14. Reminder，多条。
+15. Assignee。
+16. Tags。
+17. Related Resource。
+18. Parent Task / Subtasks。
+19. Dependencies：Blocks / Blocked By。
+20. Comments / Activity。
+
+### 6.3 Scheduled 与 Deadline
+
+UI 必须用两个独立字段和不同 Icon：
+
+- `计划执行`：Calendar Clock。
+- `截止时间`：Flag / Deadline。
+
+修改 Scheduled Time 不自动修改 Deadline。
+
+### 6.4 Recurrence
+
+显示：
+
+- Daily / Weekly / Workday / Monthly / Yearly / Custom。
+- 模式：Fixed Schedule / Completion-based。
+
+重复实例可 `跳过本次`，不强迫标记 Completed。
+
+---
+
+## 7. Subtasks
+
+Task Detail 内独立 Checklist Section：
+
+- Title。
+- Completed。
+- 可拖动排序。
+- `添加子任务`。
+
+超过合理复杂度时可 `转换为 Project`，但不自动转换。
+
+---
+
+## 8. Dependencies
+
+以关系卡片显示：
+
+- `被以下任务阻塞`。
+- `完成后将解除以下任务`。
+
+Blocked Task 顶部显示 Warning Banner，并提供跳转阻塞项。
+
+---
+
+## 9. Project 列表
+
+Project Card：
+
+- Name。
+- Status。
+- Target Date。
+- Progress：Completed Tasks / Total（仅辅助，不等同 Goal Progress）。
+- Owner / Members。
+- Related Goal。
+- Overdue Count。
+
+支持 List / Grid。
+
+---
+
+## 10. Project 详情
+
+Header：Name、Description、Status、Target Date、Members、Related Goal、Add Task。
+
+Tabs：
+
+- List。
+- Kanban。
+- Timeline。
+- Files / Related Resources。
+- Activity。
+
+Section 可配置 Backlog / Design / Development / Review / Done 等。
+
+---
+
+## 11. Kanban
+
+### 11.1 Desktop
+
+横向 Columns；每列 Header：Name、Count、Add。
+
+Task Card：Title、Priority、Deadline、Assignee、Estimate、Blocked Icon。
+
+Drag Card 改变对应分组字段；拖动前后显示目标状态，Drop 失败回滚并 Snackbar。
+
+### 11.2 Mobile
+
+默认单列 Column Selector + Card List；允许横向滑动切换列。
+
+长按 Card 后拖动排序只在显式 Edit Mode 中启用，减少误操作。
+
+---
+
+## 12. Eisenhower Matrix
+
+四象限 2×2：
+
+- 重要且紧急。
+- 重要不紧急。
+- 不重要但紧急。
+- 不重要不紧急。
+
+Task 仍是同一对象，Matrix 仅 View。
+
+Mobile 使用四个 Tabs / 可折叠 Section，避免 2×2 卡片在窄屏不可读。
+
+拖动 Task 跨象限时只修改 Important / Urgent。
+
+---
+
+## 13. Calendar
+
+### 13.1 View
+
+- Day。
+- Week。
+- Month。
+- Agenda。
+- Desktop 可 Multi-day / Year（后续）。
+
+### 13.2 Calendar Item 视觉
+
+每项必须带类型标记：
+
+- Event。
+- Task Schedule。
+- Deadline。
+- Time Block。
+- Habit。
+
+### 13.3 Day / Week
+
+左侧 Time Axis；全天区单独显示。
+
+Time Block 可拖拽改变时间；Fixed Item 拖动前提示或禁止。
+
+### 13.4 Drag Task to Calendar
+
+Desktop 从右侧 Unscheduled Tasks 拖入时间区域：
+
+- 默认创建 Scheduled Time / Time Block。
+- **不修改 Deadline**。
+
+Mobile 通过 Task More → `安排时间`。
+
+---
+
+## 14. Time Block 编辑
+
+字段：
+
+- Title。
+- Start / End。
+- Time Zone。
+- Flexible / Fixed。
+- Related Task。
+- Related Goal / Project。
+- Notes。
+- Reminder。
+
+冲突时显示 Warning：
+
+- 冲突对象。
+- 重叠时长。
+- `仍然保存`。
+- `查找其他时间`（AI / Planning 能力可用时）。
+
+不强制阻止重叠。
+
+---
+
+## 15. Goal 列表
+
+Filter：Active / Completed / Archived、Period、Type。
+
+Goal Card：
+
+- Title。
+- Period / Target Date。
+- Progress。
+- Progress Source：Manual / Derived。
+- Confidence / Health（如果业务有）。
+- Related Project Count。
+- Next Milestone。
+
+---
+
+## 16. Goal 详情
+
+Header：Title、Description、Period、Owner、Progress、Status、Update Progress。
+
+Sections：
+
+- Milestones。
+- Related Projects。
+- Related Tasks。
+- Habits。
+- Resources。
+- Check-ins。
+- Activity。
+
+Progress 由系统派生时，`Update Progress` 改为“查看计算方式 / Check-in”，避免用户误以为手动百分比一定是事实源。
+
+---
+
+## 17. OKR
+
+### 17.1 Cycle 列表
+
+Card：`2026 Q3`、Objective Count、Overall Status、Date Range。
+
+### 17.2 Objective
+
+- Objective Title。
+- Owner。
+- Progress Summary。
+- Key Result Count。
+- Confidence Summary。
+
+### 17.3 Key Result Row
+
+- KR Title。
+- Type：Numeric / Percentage / Boolean / Milestone。
+- Start Value → Current → Target。
+- Progress Bar。
+- Confidence：On Track / At Risk / Off Track。
+- Last Check-in。
+
+### 17.4 Check-in Sheet
+
+字段：
+
+- Current Value。
+- Confidence。
+- Status。
+- Note。
+- Blocker。
+- Date。
+
+Confidence 与百分比分开显示，不从一个自动推断另一个。
+
+---
+
+## 18. Habit
+
+### 18.1 Habit 首页
+
+Today Habit Cards：
+
+- Name。
+- Metric Type：Boolean / Count / Duration / Numeric。
+- Target。
+- Current。
+- Streak。
+- Check-in Button。
+
+### 18.2 Check-in
+
+Boolean：Tap 完成，Undo。
+
+Count / Numeric：Numeric Bottom Sheet。
+
+Duration：输入或从 Focus Session 关联。
+
+### 18.3 Habit Detail
+
+- Calendar Heatmap / Completion Grid。
+- Trend。
+- Schedule。
+- Related Goal / KR。
+- Notes。
+
+不将 Habit 与 Recurring Task 混为一体。
+
+---
+
+## 19. Focus
+
+### 19.1 Focus Start
+
+页面中心：
+
+- 选择 Target：Task / Project / Goal / Resource / None。
+- Mode：Stopwatch / Pomodoro / Custom Timer。
+- Duration。
+- `开始专注`。
+
+### 19.2 Focus Mode
+
+沉浸页面：
+
+- Target Title。
+- 大号 Timer。
+- Pause / Resume。
+- Finish。
+- Minimal Note。
+
+隐藏大部分导航；通知可按 Focus Policy 静音。
+
+### 19.3 Finish Sheet
+
+- Duration。
+- Completed / Interrupted。
+- Note。
+- `是否完成相关 Task` 独立 Checkbox，默认不因 Focus 结束自动勾选。
+
+---
+
+## 20. Review
+
+### Daily Review
+
+- Planned Tasks。
+- Completed。
+- Incomplete / Deferred。
+- Focus Time。
+- Habit。
+- Calendar Summary。
+- Goal Progress。
+- Reflection Note。
+
+### Weekly Review
+
+- Completed Tasks。
+- Carry-over。
+- Overdue。
+- Project Progress。
+- Goal / OKR。
+- Focus Time。
+- Habit Completion。
+- Estimate vs Actual。
+- Next Week Important Items。
+
+Monthly / Quarterly 加入长期 Goal、OKR、Time Allocation、Completed Projects、Resource Consumption / Creation。
+
+Review 可 `创建复盘文档`，跳到普通 Document，不把统计结果和主观笔记混成同一事实。
+
+---
+
+## 21. Offline
+
+必须优先支持：
+
+- Today / Inbox / Upcoming 离线查看。
+- Offline 创建 Task。
+- Offline Complete Task。
+- Habit Check-in。
+- 简单字段编辑。
+- Focus Session 本地记录。
+
+待同步项在顶部状态栏和对象 Row 上显示 `待同步`。
+
+同一字段冲突不能静默覆盖；完成状态等幂等操作可按业务规则自动合并。
+
+---
+
+## 22. 响应式
+
+- Compact：Today 单列；Calendar Day / Agenda 优先；Kanban 单列切换。
+- Medium：Today 左 Timeline + 右 Unscheduled；Calendar Week 可用。
+- Expanded：左子系统导航 / 中主内容 / 右 Context Pane；Calendar 可挂 Unscheduled Task Sidebar。
+- Large：Project Kanban / Timeline 利用宽度，但单卡仍限制最大宽度。

--- a/docs/v2/app-interaction/reading/comic-novel-reading.md
+++ b/docs/v2/app-interaction/reading/comic-novel-reading.md
@@ -1,0 +1,289 @@
+# Reading：漫画、小说与阅读器
+
+## 1. 页面目录
+
+- 阅读首页。
+- 漫画作品详情。
+- 漫画章节列表。
+- 漫画阅读器。
+- 小说作品详情。
+- 小说卷 / 章节列表。
+- 小说阅读器。
+- 阅读设置。
+
+---
+
+## 2. 阅读首页
+
+内容顺序：
+
+1. Continue Reading。
+2. 漫画。
+3. 小说 / Ebook。
+4. 待读 Collection。
+5. 最近添加。
+
+Continue Card 显示：Cover、Title、Chapter、Progress、Last Read、Offline State。
+
+---
+
+## 3. 漫画作品详情
+
+Header：
+
+- Cover。
+- Title / Alternate Title。
+- Author。
+- Status / Year。
+- Read Progress。
+- `继续阅读`。
+- `从头阅读` 放 More。
+- Download。
+- Favorite。
+
+Tabs：章节、简介、信息、关联。
+
+---
+
+## 4. 漫画章节页
+
+### 4.1 Group
+
+按 Volume / Arc 分组，Group Header：Name、完成数 / 总数。
+
+### 4.2 Chapter Row
+
+- Chapter Number。
+- Title。
+- Page Count。
+- Read State。
+- Last Read。
+- Download State。
+- Availability。
+- More。
+
+`已读` 使用 Check，不只用文本颜色。
+
+### 4.3 批量下载
+
+Selection Mode：选择 Volume / Chapter → Download。
+
+显示预计大小（可知时）和空间提示。
+
+---
+
+## 5. 漫画阅读器
+
+### 5.1 模式
+
+必须支持：
+
+- 单页。
+- 双页。
+- 连续纵向滚动。
+- 条漫。
+- Left-to-Right。
+- Right-to-Left。
+
+### 5.2 Immersive UI
+
+默认内容全屏，Chrome 隐藏。
+
+Tap 中间区域显示：
+
+Top Bar：Back、Chapter Title、More。
+
+Bottom Bar：Page `12 / 48`、Slider / Scrubber、Previous Chapter、Next Chapter、Settings。
+
+### 5.3 单页
+
+页面居中 Fit Contain。
+
+- Tap 左 / 右区域翻页，方向受阅读方向设置影响。
+- Pinch Zoom。
+- Zoom 后拖动图片，禁止误触翻页。
+
+### 5.4 双页
+
+Desktop / Tablet 默认更适合。
+
+- 奇偶页配对规则可设置封面是否单页。
+- 窄屏自动回退单页并提示一次。
+
+### 5.5 连续滚动 / 条漫
+
+- 使用虚拟化 / 懒加载。
+- 当前阅读位置按可见页和偏移保存。
+- Page Gap 可配置。
+
+### 5.6 Page Scrubber
+
+拖动显示小预览缩略图与页码。
+
+如果缩略图未生成，显示页码而不是阻断操作。
+
+### 5.7 章节切换
+
+到末页显示轻量 Chapter End Sheet：
+
+- 已完成章节。
+- 下一章标题。
+- `下一章`。
+- `返回作品`。
+
+可设置自动进入下一章。
+
+---
+
+## 6. 漫画阅读设置
+
+Bottom Sheet：
+
+- Reading Mode。
+- Direction。
+- Fit Width / Fit Height / Contain。
+- Page Gap。
+- Background：Black / Dark / Light / System。
+- Keep Screen On。
+- Auto Next Chapter。
+
+设置分为：`本书` 与 `全局默认`，避免用户改一本书导致全部书意外改变。
+
+---
+
+## 7. 小说作品详情
+
+Header：Cover、Title、Author、Progress、Continue、Download、Favorite。
+
+Tabs：目录、简介、信息、关联。
+
+目录允许 Volume 折叠，默认展开当前阅读位置所在卷。
+
+---
+
+## 8. 小说章节 Row
+
+- Chapter Number / Index。
+- Title。
+- Estimated Read Time（可计算时）。
+- Read / Unread。
+- Downloaded。
+- More。
+
+Tap 打开阅读器并从上次位置继续；More 提供“从头打开”。
+
+---
+
+## 9. 小说阅读器
+
+### 9.1 内容区
+
+正文容器默认最大宽度：
+
+- Mobile：屏宽减左右 Padding。
+- Tablet：600–720dp。
+- Desktop：720–860dp。
+
+不在超宽屏把一行文字拉到 1500dp。
+
+### 9.2 Top / Bottom Chrome
+
+Tap 中间显示：
+
+Top：Back、Book Title、Chapter Title、More。
+
+Bottom：Chapter Progress、Previous、TOC、Next、Settings。
+
+### 9.3 阅读方式
+
+支持：
+
+- Continuous Scroll。
+- Paginated（Flutter 实现可后续评估，但文档保留产品语义）。
+
+### 9.4 进度
+
+保存：Chapter + 字符 / 段落 / CFI 类稳定定位语义，最终由格式适配层决定。
+
+只保存屏幕像素 Offset 不足以支持跨设备恢复。
+
+---
+
+## 10. 小说阅读设置
+
+分组：
+
+### Typography
+
+- Font Family。
+- Font Size。
+- Font Weight（允许时）。
+- Line Height。
+- Paragraph Spacing。
+- Letter Spacing。
+
+### Layout
+
+- Content Width。
+- Page Margin。
+- Text Alignment。
+
+### Theme
+
+- System。
+- Light。
+- Sepia。
+- Dark。
+- OLED Black。
+
+### Behavior
+
+- Keep Screen On。
+- Volume Key Page Turn（Android 可选）。
+- Auto Next Chapter。
+
+实时预览当前正文，点击“重置”恢复书籍 / 全局默认。
+
+---
+
+## 11. Annotation / Link
+
+普通 Document / Resource Link 如果存在：
+
+- 选中文字可创建普通 Note / Quote（未来能力）。
+- Internal Link Tap 打开目标 Resource。
+
+私密引用必须遵循 Secure Domain，不把 Private Note 的存在反向暴露。
+
+---
+
+## 12. AI 阅读辅助
+
+AI 可用时 More → `阅读助手`：
+
+- 本章摘要。
+- 人物 / 实体回顾。
+- 翻译选中内容。
+- 解释选中内容。
+
+AI 功能必须标注生成内容；用户关闭 AI 或当前内容不允许发送外部 Provider 时隐藏 / 限制。
+
+漫画 OCR / 翻译属于 AI Job 时显示处理进度，不覆盖原始页面。
+
+---
+
+## 13. Offline
+
+- 已下载章节完全离线可读。
+- Cache 可用于当前阅读，但不标记为 Downloaded。
+- Offline 阅读进度本地记录。
+- 章节下载失败支持单章重试。
+
+---
+
+## 14. 响应式
+
+- Compact：沉浸单页 / 单列正文。
+- Medium：漫画可默认单页或双页由方向与宽度决定；目录可 Side Sheet。
+- Expanded：漫画双页；小说左 TOC 280dp + 正文，TOC 可收起。
+- Large：正文保持最大阅读宽度，左右空白可作为控制 / Annotation Pane，不拉宽文字。

--- a/docs/v2/app-interaction/video/video-media.md
+++ b/docs/v2/app-interaction/video/video-media.md
@@ -1,0 +1,392 @@
+# Video：动画、影视、通用视频与播放器
+
+## 1. 页面目录
+
+- 视频首页。
+- 作品详情。
+- Season / Episode 浏览。
+- Episode 详情 / 版本选择。
+- Video Player。
+- 字幕 / 音轨 / 版本面板。
+- 播放设置。
+- Together Room 入口。
+
+---
+
+## 2. 视频首页
+
+### 2.1 内容顺序
+
+1. Continue Watching。
+2. 最近更新剧集。
+3. 我的追番 / 收藏。
+4. 电影。
+5. 通用视频。
+6. 最近添加。
+
+每区 Header：标题 + 查看全部。
+
+### 2.2 Continue Card
+
+- 16:9 Preview。
+- 作品名。
+- Episode 标题 / 编号。
+- Progress Bar。
+- `剩余 xx 分钟`（可计算时）。
+- 本地状态 Chip：Downloaded / Cached。
+
+Tap 直接继续播放。
+
+---
+
+## 3. 作品详情
+
+### 3.1 Header
+
+- Poster。
+- Display Title。
+- Original Title。
+- Year / Season / Type Chips。
+- 收藏状态。
+- 当前观看状态。
+- `继续观看` / `播放`。
+- `下载`。
+- `一起看`。
+- More。
+
+### 3.2 Episode Progress Summary
+
+显示：
+
+- 已看 `8 / 12`。
+- 总观看进度。
+- 下一集。
+
+### 3.3 Tabs
+
+- 剧集。
+- 简介。
+- 信息。
+- 关联。
+
+---
+
+## 4. Season / Episode 浏览
+
+### 4.1 Season Selector
+
+作品存在多个 Season / 篇章时使用 Dropdown / Segmented 控件。
+
+字段：Season Name、Episode Count、完成进度。
+
+### 4.2 Episode List Row
+
+从左到右：
+
+- Episode Number。
+- 16:9 Thumbnail（宽屏）或小封面。
+- Title。
+- Air Date。
+- Duration。
+- Progress。
+- Availability。
+- Download State。
+- More。
+
+Compact 可折叠为：Thumbnail + Number/Title + Progress，其他信息放第二行。
+
+### 4.3 Episode 状态
+
+- 未观看：无进度。
+- 观看中：线性进度。
+- 已完成：Check Icon。
+- 无媒体附件：Disabled Play + `无可播放内容`。
+- Restoring：显示恢复状态，不允许假装播放。
+
+### 4.4 Episode More
+
+- 从头播放。
+- 标记已看 / 未看。
+- 下载。
+- 选择版本。
+- 查看详情。
+- 分享（有权限时）。
+
+---
+
+## 5. Episode 详情 / 版本选择
+
+当一个 Episode 存在多个 Attachment：
+
+每个 Version Card 显示：
+
+- Display Name / Release Group。
+- Resolution。
+- Codec。
+- HDR / SDR。
+- Audio Summary。
+- Subtitle Summary。
+- File Size。
+- Availability。
+- Local Download State。
+
+主动作：`播放此版本`。
+
+用户可设置 `默认选择规则`，例如优先本地下载、优先 1080p；规则必须可解释，不静默选择 Missing / Corrupted 版本。
+
+---
+
+## 6. Video Player 基础布局
+
+播放器属于 Immersive Surface。
+
+### 6.1 Compact 横屏
+
+```text
+┌────────────────────────────────────┐
+│ Back   Title              Cast/More│
+│                                    │
+│              Video                 │
+│                                    │
+│             Play/Pause             │
+│                                    │
+│ 00:12 ━━━━━━━●━━━━━━━━━━ 23:40     │
+│ Prev  Next  Speed  Subtitle  Tracks│
+└────────────────────────────────────┘
+```
+
+控制层默认隐藏，Tap 显示 3–5 秒；拖动 / 菜单操作期间不自动隐藏。
+
+### 6.2 Desktop
+
+- 视频画布占主要区域。
+- Bottom Controls 两层：进度 + 控制按钮。
+- 可选右侧 Episode / Queue Pane，宽 320–400dp。
+- 双击视频切换全屏（Desktop）。
+
+---
+
+## 7. 播放器控件
+
+### 7.1 Top Bar
+
+- Back。
+- Episode / Resource Title。
+- Room 状态（在房间中时）。
+- Picture-in-Picture（平台支持时）。
+- More。
+
+### 7.2 Center Controls
+
+- Rewind 10s。
+- Play / Pause。
+- Forward 10s。
+
+Mobile 左右双击区域可快退 / 快进，但必须显示动画反馈和累计秒数。
+
+### 7.3 Progress
+
+- Current Time。
+- Slider。
+- Buffered Range（播放器可提供时）。
+- Duration。
+
+拖动时显示 Preview Thumbnail（存在派生预览时）+ 时间。
+
+拖动结束后才提交最终 Seek；过程中可节流预览。
+
+### 7.4 Bottom Actions
+
+- Previous / Next Episode。
+- Speed。
+- Subtitle。
+- Audio Track。
+- Version / Quality。
+- Danmaku（插件 / 能力可用时）。
+- Fullscreen。
+
+---
+
+## 8. Subtitle 面板
+
+Bottom Sheet / Side Sheet：
+
+顶部 `字幕`。
+
+列表：
+
+- Off。
+- 每条 Subtitle：Language、Title、Format、Source、是否本地下载。
+
+选中项 Check。
+
+底部 `字幕样式`：
+
+- 字号。
+- 位置。
+- 背景 / 描边。
+- 字体（平台支持）。
+- 延迟 Offset。
+
+字幕切换即时生效，不退出播放器。
+
+---
+
+## 9. Audio Track 面板
+
+每条：
+
+- Language。
+- Title。
+- Codec。
+- Channel Layout。
+- Default 标识。
+
+Tap 切换，失败显示 Snackbar 并恢复原 Track。
+
+---
+
+## 10. Version / Quality 面板
+
+区分两个概念：
+
+- `版本`：不同 Attachment / Release。
+- `清晰度`：同一源的转码 / Adaptive Variant。
+
+列表项显示：Resolution、Bitrate、Codec、HDR、Size / Estimated Bandwidth、Local / Remote。
+
+弱网络下可提示“当前网络可能无法稳定播放”，但不强制降低质量。
+
+---
+
+## 11. 播放速度
+
+Preset：0.5、0.75、1.0、1.25、1.5、2.0。
+
+可选自定义范围。
+
+当前速度在按钮上显示，例如 `1.25×`。
+
+---
+
+## 12. 手势
+
+Mobile Fullscreen：
+
+- 单击：显示 / 隐藏控制。
+- 左区域双击：后退 10s。
+- 右区域双击：前进 10s。
+- 横向滑动进度仅在设置允许时启用，避免和系统返回冲突。
+- 亮度 / 音量竖滑属于平台增强能力，默认可关闭。
+
+所有手势必须在 Settings 有说明。
+
+---
+
+## 13. 键盘快捷键
+
+Desktop：
+
+- Space：Play/Pause。
+- Left / Right：±5s。
+- `J/L`：±10s（可选）。
+- Up / Down：Volume。
+- `F`：Fullscreen。
+- `M`：Mute。
+- `[` / `]`：速度调整（可选）。
+- `Esc`：退出全屏 / 关闭 Overlay。
+
+输入框、聊天框聚焦时不拦截。
+
+---
+
+## 14. 播放进度保存
+
+- 周期性节流保存。
+- Pause / Exit 时立即尝试保存。
+- Offline 时写 Local Pending Progress。
+- Reconnect 后同步。
+- 冲突时优先采用业务定义的合理进度策略，不简单 Last Write Wins。
+
+播放完成阈值由服务端 / 客户端统一产品规则决定，UI 不自行猜测不同阈值。
+
+---
+
+## 15. Offline
+
+若已下载：
+
+- Player 顶部显示 `离线播放` Chip。
+- 不尝试无意义地等待服务器。
+- Progress 保存为待同步。
+
+若只有部分 Cache：
+
+- 可以播放缓存范围，但不得把它标记成“已下载”。
+- 即将进入未缓存范围且服务器不可达时，明确提示。
+
+---
+
+## 16. Room / 一起看
+
+### 16.1 创建入口
+
+作品详情 `一起看`，或 Player More → `创建房间`。
+
+Create Room Sheet：
+
+- Room Name。
+- 当前 Episode。
+- Invite Scope。
+- 是否允许成员控制播放。
+- 创建。
+
+### 16.2 Player 中 Room 状态
+
+Top Bar 显示成员头像叠层 + 人数。
+
+打开 Room Panel：
+
+- 成员列表。
+- Host 标识。
+- Chat / Event Timeline。
+- Queue。
+- Control Permission。
+
+### 16.3 同步反馈
+
+远端 Seek / Pause 时显示轻量 Toast：`房主跳转到 12:30`。
+
+网络重连：显示 `正在重新同步房间状态`，完成后明确是否调整了本地进度。
+
+---
+
+## 17. 播放错误
+
+错误分类：
+
+- Network。
+- Permission。
+- Attachment Missing。
+- Corrupted。
+- Codec Unsupported。
+- Restore Required。
+- Processing。
+
+错误 Overlay 必须给对应动作，例如：
+
+- 重试。
+- 选择其他版本。
+- 等待恢复并通知。
+- 下载兼容版本。
+
+不能所有情况只显示“播放失败”。
+
+---
+
+## 18. 响应式
+
+- Compact Portrait：作品详情单列；Player 建议进入横屏沉浸模式但不强制系统旋转。
+- Medium：Episode List 可和简介分栏。
+- Expanded：作品 Detail 左信息右 Episode；Player 可右侧固定 Episode Pane。
+- Large：Player 内容最大化，控制栏不随 4K 宽度无限拉长，中央控制区保持可达。


### PR DESCRIPTION
概述

本 PR 为 Ikaros V2 新增官方客户端 App 的页面布局与交互设计文档。

与旧版 App 页面结构不同，本次设计不以现有 V1 Flutter App 为信息架构基准，也不是将 CMS Console 页面简单缩小后迁移到客户端，而是直接基于 "docs/v2/" 中已经确定的 V2 PRD、各业务子系统设计与平台能力边界，重新设计 V2 App 的页面结构、导航体系、响应式布局与交互规范。

设计目标是以 Markdown 作为“文档化原型”，直接描述页面中每一个区域、字段、卡片、组件、状态及其交互逻辑，为后续 Flutter 客户端实现提供 UI / UX 基线。

设计基线

主要参考以下 V2 文档：

- "Product-Requirements-Document.md"
- "Productivity-Planning-Subsystem-Design.md"
- "Personal-Finance-Accounting-Subsystem-Design.md"
- "Private-Notes-Subsystem-Design.md"
- "Password-Manager-Subsystem-Design.md"
- "AI-Intelligence-Subsystem-Design.md"
- "AI-Persona-System-Design.md"
- "Data-Analytics-Statistics-Subsystem-Design.md"
- "Platform-Integration-Automation-Design.md"
- "Security-Identity-Authorization-Crypto-Subsystem-Design.md"
- "Secure-Data-Foundation-Design.md"
- "Platform-Administration-Operations-Subsystem-Design.md"

因此 App 的页面结构与 V2 的 Resource、Attachment、Activity、Progress、Planning、Secure Domain、AI、Automation 等领域语义保持一致。

新增目录

docs/v2/app-interaction/
├── README.md
├── foundation/
├── access/
├── home/
├── library/
├── video/
├── reading/
├── music/
├── photos/
├── documents/
├── games/
├── productivity/
├── finance/
├── private-notes/
├── password-manager/
├── ai/
├── analytics/
├── collaboration/
├── automation/
├── offline/
├── notifications/
└── account/

根目录 "README.md" 作为整个 App 的：

- 页面布局总纲
- 信息架构
- 导航目录
- 响应式规范
- 全局组件规范
- 全局状态规范
- Flutter / Material 3 组件映射说明

各业务子系统的详细页面布局和交互说明分别保存在对应子目录中。

App 信息架构

完整菜单按照子系统进行分组，并且默认全部收起。

主要分组包括：

首页与发现

- 首页
- 全局搜索
- 我的活动
- 通知中心

内容库

- 统一资源库
- Collection / 标签
- 视频与影视
- 漫画与小说
- 音乐
- 图片与相册
- 文章与文档
- 游戏与数字资料

计划与生活

- Today / Inbox
- Task / Project
- Calendar
- Goal / OKR
- Habit / Focus / Review
- 个人财务

私密与安全

- 私密笔记
- 密码管理

AI 与洞察

- AI Assistant
- Persona
- AI Memory / Privacy
- 数据洞察

协作与自动化

- 分享
- Room
- Automation
- Import / Sync

本地与设备

- 我的下载
- 离线内容
- 缓存与空间

我的

- 个人资料
- 安全与会话
- 通知偏好
- 外观与可访问性
- 客户端设置
- 关于

响应式设计

客户端后续暂定采用 Flutter，因此页面设计统一按照 Material Design 3 和 Flutter 响应式布局模型设计。

不按照 Android / Windows 等具体设备类型判断页面，而根据实际可用宽度划分：

Size Class| 宽度| 导航方式
Compact| "< 600dp"| Bottom Navigation + Navigation Drawer
Medium| "600–839dp"| Navigation Rail + Drawer
Expanded| "840–1199dp"| Permanent Side Navigation
Large| ">= 1200dp"| Permanent Side Navigation + Context Pane

移动端 Bottom Navigation 仅保留最高频入口：

1. 首页
2. 资源库
3. Today
4. AI
5. 我的

完整业务菜单通过 Drawer 展示。

桌面宽屏则使用固定侧边栏展示完整的分组导航。

页面文档粒度

本次文档不只描述“这里有一个列表”或“这里放一个按钮”，而是尽可能明确：

- 页面从上到下 / 从左到右的区域结构
- 每个区域展示哪些字段
- Card 内部字段顺序
- 主按钮、次按钮与危险操作
- Chip、Tab、Menu、Dialog、Bottom Sheet 等组件
- Tap / Double Tap / Long Press
- Desktop Hover / Right Click
- 键盘快捷键
- 搜索、筛选、排序
- 下拉刷新与分页
- 编辑和保存流程
- 删除、回收站与永久删除的区别
- 后台任务状态
- 离线操作
- 待同步状态
- 权限不足
- Secure Domain Locked / Unlocked
- Processing / Restoring / Missing / Corrupted 等资源状态
- Compact / Medium / Expanded / Large 下的布局变化

目标是让开发人员可以直接根据文档实现页面，而不必依赖额外原型图解释页面结构。

V2 业务语义在 App 中的体现

本次设计同时避免了若干容易在 UI 层被错误简化的 V2 领域语义。

例如：

- Resource 与 Attachment / Blob / Placement 保持区别。
- Cache 与用户主动 Download 保持区别。
- Scheduled Time 与 Deadline 保持区别。
- Productivity Task、Calendar Event、Time Block 保持区别。
- Finance Transfer 作为一个完整业务事实展示。
- 对账异常不会通过静默修改历史交易解决。
- Ikaros 登录与 Password Vault / Private Notes Vault 解锁保持区别。
- 普通管理员权限不等于 Secure Domain 解密权限。
- Private Notes 锁定后不泄露标题、Notebook、Tag 等 Protected Metadata。
- AI Suggestion 不直接成为业务事实。
- AI 高风险 Tool 调用需要经过权限、风险策略与用户确认。
- Offline Change 明确显示 Pending Sync，而不是假装已经同步成功。
- Activity 与 Audit 保持不同产品语义。

App 与 CMS Console 的边界

V2 App 定位为用户侧客户端，不是后台管理系统的移动版。

因此以下管理员专属能力不进入普通 App 主菜单：

- 用户与角色管理
- 平台级权限矩阵
- 平台参数管理
- 字典管理
- CMS 菜单管理
- 系统级 Audit
- Scheduled Job 管理
- Subsystem Health 管理
- Runtime Metrics
- Storage Provider 管理
- Blob GC / Retention 策略
- 其他平台级运维能力

这些页面仍属于 CMS Console。

App 只展示与当前用户行为直接相关的必要状态，例如：

- 内容正在恢复
- 下载 / 同步进度
- 自己的活跃 Session
- 自己的通知
- 后台操作结果
- 当前服务端连接状态

Secure Domain

Private Notes 和 Password Manager 作为正式 App 子系统设计，而不是普通 Note 页面增加一个 "private" 开关。

相关文档覆盖：

- Vault Locked Surface
- Unlock
- Biometrics
- Local Encrypted Cache
- Offline-first
- Local Search
- Conflict Resolution
- Secure Attachment Viewer
- Screenshot / App Switcher Protection
- Clipboard Sensitive Data
- Step-up Verification
- Recovery
- Encrypted Export

以符合 V2 Secure Data Foundation 的安全边界。

Offline / Download / Cache

根据 V2 PRD 对客户端 Offline-first 的要求，单独设计：

- 我的下载
- 下载队列
- 离线资源
- 客户端缓存
- 空间占用
- 待同步操作
- 同步冲突

并明确：

Download ≠ Cache

用户主动下载的数据是可管理的离线副本，而普通客户端缓存属于可淘汰实现数据。

AI

AI 不只是独立 Chat 页面，同时作为横向能力融入 App。

设计覆盖：

- AI Assistant
- Conversation
- Persona 选择
- Scenario
- Context
- Memory
- Privacy
- Tool Call
- Action Draft
- 高风险操作确认
- Provenance
- AI Job
- Result Feedback

AI 仍然遵循：

AI Suggestion
≠
Business Fact

以及：

Agent Permission
⊆
Current Principal Permission

变更规模

本 PR：

- 新增 "docs/v2/app-interaction/"
- 新增 22 个 Markdown 文档
- 约 7,700 行 App 页面布局与交互说明
- 不修改业务代码
- 不修改现有 V2 领域设计
- 不修改 CMS 原型

后续

后续 Flutter App 的页面实现应优先以本目录作为 UI / UX 基线。

随着 V2 子系统设计继续演进，可继续在对应 "app-interaction/<subsystem>/" 下补充：

- 新页面
- 新交互流程
- 特殊状态
- 平台差异
- Keyboard / Mouse / Touch 细节
- Accessibility
- Flutter 组件约束

使 Markdown 文档持续承担 App 的“可实现交互原型”职责。