### PR TITLE
docs(v2): add personal drive and file synchronization subsystem design

### DIFF
--- a/docs/v2/Personal-Drive-File-Synchronization-P0-Semantics.md
+++ b/docs/v2/Personal-Drive-File-Synchronization-P0-Semantics.md
@@ -1,0 +1,1026 @@
+# Ikaros V2 Personal Drive / File Synchronization P0 关键语义补充
+
+| 项目 | 内容 |
+|---|---|
+| 文档名称 | Personal Drive / File Synchronization P0 Semantics |
+| 适用版本 | Ikaros V2 |
+| 文档版本 | v0.1 |
+| 编写日期 | 2026-08-31 |
+| 状态 | 草案（Draft） |
+| 主设计 | `Personal-Drive-File-Synchronization-Subsystem-Design.md` |
+| 系统基线 | `System-Overview-Design.md` |
+| API 基线 | `API-Convention-Design.md` |
+| 数据库基线 | `Database-Overview-Design.md` |
+| 依赖设计 | `Attachment-Blob-Storage-Subsystem-Design.md`、`Offline-Cache-Device-Synchronization-Subsystem-Design.md`、`Photo-Album-Image-Asset-Subsystem-Design.md` |
+
+> 本文档补充 `Personal-Drive-File-Synchronization-Subsystem-Design.md` 中会直接影响 P0 Server / Desktop / Mobile Sync Engine 实现的一致性语义。
+>
+> 本文档不是第二套 Drive 领域模型。Drive Space、Drive Node、File Revision、Sync Binding、Attachment / Blob、Photo Projection 等对象仍以主设计为准；本文只把容易在不同客户端实现中产生歧义的状态机、时间、事件归并、配额和备份安全条件固定下来。
+
+---
+
+## 1. 补充目标
+
+本补充设计重点解决以下问题：
+
+1. Drive Change Feed 中究竟什么算一次可同步变化。
+2. Trash 后 Restore 如何避免被旧 Tombstone 再次删除。
+3. Drive 时间与源文件时间如何分离。
+4. Office、IDE、编辑器采用临时文件替换保存时如何避免误判为删除 + 新建。
+5. 并发 Upload Session 如何正确占用和释放配额。
+6. Camera Backup 在什么条件下才可以告诉用户“已安全备份，可以释放本地空间”。
+7. 多个 Sync Binding 的本地或远端 Scope 重叠时如何防止同步回环。
+8. File / Folder Copy 的 Revision History 到底如何处理。
+9. Windows / macOS / Linux 文件系统差异在 P0 中支持到什么程度。
+10. iCloud Photos、Android 云端媒体、Limited Permission 等“发现 Asset 但暂时拿不到 Original”的场景如何建模。
+11. Shared Folder 是否允许直接作为 P0 TWO_WAY Sync Root。
+
+核心原则：
+
+> **同步正确性优先于“看起来实时”；任何无法证明为无损的自动收敛，都不得通过路径、mtime 或 watcher 事件猜测后静默覆盖用户内容。**
+
+---
+
+## 2. Drive Change Generation
+
+### 2.1 Change Feed 与领域事件分离
+
+Drive Event 用于跨领域集成；Drive Change Feed 用于设备可靠同步。
+
+两者可以来自同一次领域事务，但不是同一个概念：
+
+```text
+Drive Command
+     ↓
+Drive Domain Transaction
+     ├── Outbox Domain Event
+     └── Drive Change Record
+               ↓
+        Device Sync Feed
+```
+
+Domain Event 可以按消费者需求演进；Change Feed 必须满足设备增量重放、排序、幂等和 Full Resync 判断。
+
+### 2.2 Change Generation
+
+每个 Drive Space 需要一个服务端权威、单调递增、可比较的 Change Generation / Sequence。
+
+建议语义：
+
+```text
+Drive Change
+├── drive_space_id
+├── sequence: bigint
+├── node_id
+├── mutation_kind
+├── node_version
+├── revision_id?
+├── previous_parent_id?
+├── previous_name?
+├── actor / device
+├── occurred_at
+└── contract_version
+```
+
+`sequence`：
+
+- 由服务端产生；
+- 在一个 Drive Space 内严格定义顺序；
+- 不由客户端时间生成；
+- 不使用 UUIDv7 时间部分替代；
+- 不要求等同数据库 WAL / transaction id；
+- 可以作为 Offline Sync Runtime 中 Drive Projection 的 Cursor 基础。
+
+### 2.3 Mutation Kind
+
+P0 至少区分：
+
+- `NODE_CREATED`；
+- `CONTENT_REVISION_CREATED`；
+- `NODE_RENAMED`；
+- `NODE_MOVED`；
+- `NODE_TRASHED`；
+- `NODE_RESTORED`；
+- `NODE_PURGED`。
+
+未来可以增加：
+
+- ACL / Share Projection Change；
+- Pin / Favorite；
+- Special Folder Change；
+- Metadata Change。
+
+但客户端不得把所有变化统一解释成“文件 modified”。
+
+### 2.4 Rename / Move 不是 Delete + Create
+
+服务端已知 Node Identity 时：
+
+```text
+NODE_RENAMED(node_id=123)
+```
+
+必须保持 `node_id = 123`。
+
+同步客户端收到该 Change 后应尽量执行本地 Rename，而不是：
+
+```text
+Delete old path
+Download same bytes to new path
+```
+
+如果本地文件系统无法原子 rename，再由客户端降级实现，但映射层仍保持同一 Remote Node Identity。
+
+### 2.5 Cursor 推进规则
+
+客户端只有在某个 Change 已经：
+
+1. 成功应用到本地；或
+2. 被确定为无需应用但已持久记录原因；或
+3. 被持久化为可恢复 Conflict；
+
+之后，才能推进该 Change 对应的 Cursor。
+
+不能“先 Ack Cursor，再异步写文件”。
+
+---
+
+## 3. Node Version、Lifecycle Generation 与 Restore
+
+### 3.1 问题
+
+设备 A 删除文件：
+
+```text
+ACTIVE
+  ↓ sequence 20
+TRASHED
+```
+
+设备 B 长期离线。
+
+用户随后从 Web 恢复：
+
+```text
+TRASHED
+  ↓ sequence 21
+ACTIVE
+```
+
+如果 B 只保存一个“此 Node 曾被删除”的 Tombstone，而不理解后续 Restore Generation，则 B 重连后可能再次删除已经恢复的文件。
+
+### 3.2 Node Version
+
+Drive Node 每次会影响同步可见状态的领域变更都增加 `node_version`。
+
+包括：
+
+- rename；
+- move；
+- trash；
+- restore；
+- purge request / purge；
+- current revision 切换。
+
+Node Version 是乐观并发与快照版本，不替代 Change Sequence。
+
+### 3.3 Tombstone 不是永久真相
+
+Tombstone 表示：
+
+> 在某个服务端 sequence 上，这个 Node 进入了删除传播状态。
+
+它至少需要：
+
+```text
+Tombstone
+├── node_id
+├── tombstone_sequence
+├── node_version
+├── lifecycle = TRASHED | PURGED
+├── deleted_at
+└── retention_deadline
+```
+
+### 3.4 Restore 语义
+
+Trash Restore：
+
+- 保持同一个 `node_id`；
+- 增加 `node_version`；
+- 产生新的 `NODE_RESTORED` Change Sequence；
+- 旧 Tombstone 不能覆盖比自己更新的 Node Version / Sequence。
+
+因此：
+
+```text
+node 123
+v5 ACTIVE
+   ↓ seq 20
+v6 TRASHED
+   ↓ seq 21
+v7 ACTIVE
+```
+
+设备收到 seq 20 和 seq 21 后，最终必须收敛到 v7 ACTIVE。
+
+### 3.5 Purge 后不得复活同一 Node
+
+`PURGED` 与 `TRASHED` 不同。
+
+P0 规则：
+
+- Trash 可以 Restore 同一 Node Identity；
+- Permanent Purge 完成后，该 Node Identity 不再恢复为 ACTIVE；
+- 如果用户重新上传相同内容，应创建新的 Drive Node ID；
+- 即使底层 Blob 因其他引用尚未 GC，也不能据此复活已 Purged Drive Node。
+
+---
+
+## 4. 文件时间语义
+
+### 4.1 必须区分的时间
+
+Drive 至少区分：
+
+```text
+Drive Metadata Time
+├── created_at
+└── updated_at
+
+Content Time
+└── content_modified_at?
+
+Source Time Hints
+├── source_created_at?
+└── source_modified_at?
+```
+
+含义：
+
+- `created_at`：Drive Node 在 Ikaros 中创建的真实时间点；
+- `updated_at`：Drive Node 领域状态最后变化时间；
+- `content_modified_at`：当前文件内容在源语义中的最后修改时间；
+- `source_created_at`：来源文件系统或 Provider 提供的创建时间 Hint；
+- `source_modified_at`：来源文件系统提供的修改时间 Hint。
+
+### 4.2 上传时间不覆盖源修改时间
+
+例如：
+
+```text
+source_modified_at = 2022-03-01T10:00:00+08:00
+Drive upload at     = 2026-08-31T10:00:00+08:00
+```
+
+上传后：
+
+- Drive `created_at` 是 2026；
+- `content_modified_at` 可以保留可信的 2022 源修改语义；
+- UI 可以同时显示“修改于 2022 / 添加于 2026”。
+
+### 4.3 时间不是内容身份
+
+任何情况下：
+
+```text
+mtime + size
+```
+
+只能用于快速变化候选筛选，不能证明内容相同。
+
+### 4.4 时间可信度
+
+Source Time 可能：
+
+- 被复制工具保留；
+- 被用户手动修改；
+- 因文件系统精度丢失；
+- 因时区处理错误；
+- 根本不存在。
+
+因此同步冲突判定仍使用 Revision / Base Version / Fingerprint，而不是“谁的时间更新”。
+
+---
+
+## 5. Atomic Save / Change Coalescing
+
+### 5.1 问题
+
+很多编辑器保存：
+
+```text
+Create .tmp
+Write new bytes
+fsync
+Delete / replace original
+Rename .tmp -> report.docx
+```
+
+Watcher 可能观察到：
+
+```text
+CREATE .tmp
+MODIFY .tmp
+DELETE report.docx
+RENAME .tmp report.docx
+```
+
+如果同步引擎逐条立即上传，会错误产生：
+
+- Trash；
+- New File；
+- Conflict Copy；
+- 多个无意义 Revision。
+
+### 5.2 Event 只是 Hint
+
+OS File Watcher / Journal Event 只能用于“需要重新检查哪些路径”。
+
+P0 不允许：
+
+> 一个 watcher event = 一个远端 Drive Mutation。
+
+正确模型：
+
+```text
+Watcher / Journal Events
+       ↓
+Dirty Scope / Candidate Set
+       ↓ debounce / settle
+Re-stat / map / fingerprint
+       ↓
+Logical Local Delta
+       ↓
+Drive Mutation
+```
+
+### 5.3 Settle Window
+
+客户端可以对活跃文件设置短暂 Settle / Debounce Window，等待连续写入稳定。
+
+窗口：
+
+- 属于客户端实现优化；
+- 不应写死为跨平台唯一毫秒值；
+- 大文件写入时可以结合 size stable / handle state / journal signal；
+- 不得无限等待导致文件永不备份。
+
+### 5.4 Atomic Replace Detection
+
+若出现：
+
+- 原路径消失；
+- 同目录出现新 local item；
+- 新对象最终占用相同相对路径；
+- 内容发生变化；
+- 时间窗口合理；
+
+客户端应优先将其解释为：
+
+> 原 File Node 的新 Content Revision 候选
+
+而不是直接产生 Delete + Create。
+
+但若证据不足，宁可进入保守 Reconcile，也不能错误合并两个不同用户文件。
+
+### 5.5 Temporary File Filter
+
+P0 默认建议忽略常见临时文件模式，但规则必须可配置，例如：
+
+- `*.tmp`；
+- `~$*`；
+- `.DS_Store`；
+- editor swap file；
+- application lock file。
+
+不能仅凭扩展名永久禁止用户显式上传某个真实文件。
+
+---
+
+## 6. Quota Reservation
+
+### 6.1 为什么需要 Reservation
+
+假设用户剩余 1 GiB 配额，同时创建 10 个 1 GiB Upload Session。
+
+如果只在 `Begin Upload` 查询当前已用空间而不占位，10 个 Session 都可能被接受。
+
+### 6.2 Reservation 生命周期
+
+P0 语义：
+
+```text
+Begin Upload
+     ↓
+Quota Check + Reserve
+     ↓
+Upload Session ACTIVE
+     ↓
+Finalize
+     ↓
+Commit Actual Logical Usage
+     ↓
+Release Reservation
+```
+
+失败路径：
+
+```text
+Abort / Expire / Reject Finalize
+     ↓
+Release Reservation
+```
+
+### 6.3 Reservation 字段
+
+建议概念：
+
+```text
+DriveQuotaReservation
+├── id
+├── drive_space_id
+├── upload_session_id
+├── reserved_bytes
+├── state: ACTIVE | COMMITTED | RELEASED | EXPIRED
+├── expires_at
+├── created_at
+└── updated_at
+```
+
+### 6.4 Replace File 的配额
+
+Replace File 创建新 Revision 时，配额增长取决于 Revision Retention Policy。
+
+P0 推荐在 Finalize 前按“新 Revision 将产生的最坏逻辑增量”预留，并在提交后根据实际 Retention 结果结算。
+
+### 6.5 Dedup 不降低用户逻辑 Reservation
+
+即使 Storage 最终发现 Blob 已存在，P0 用户逻辑配额仍按 Drive 的逻辑引用大小结算。
+
+这样：
+
+- 不依赖物理去重时机；
+- 不泄露其他用户内容存在性；
+- Reservation 规则稳定。
+
+---
+
+## 7. Backup Verification 与 Free Up Space
+
+### 7.1 Upload Complete 不等于 Backup Verified
+
+移动端不能仅因为 HTTP Upload 成功就建议删除本地照片。
+
+至少区分：
+
+```text
+DISCOVERED
+  ↓
+QUEUED
+  ↓
+UPLOADING
+  ↓
+UPLOAD_COMPLETE
+  ↓
+BLOB_VERIFIED
+  ↓
+DRIVE_COMMITTED
+  ↓
+BACKUP_VERIFIED
+```
+
+Photo Projection 可以并行或随后执行：
+
+```text
+BACKUP_VERIFIED
+  ↓
+PHOTO_PROJECTION_PENDING
+  ↓
+PHOTO_PROJECTED | PHOTO_PROJECTION_FAILED
+```
+
+### 7.2 BACKUP_VERIFIED 条件
+
+P0 中，一个 Camera Asset 只有同时满足以下条件，才能进入 `BACKUP_VERIFIED`：
+
+1. Upload Session Finalize 已完成；
+2. 服务端已经计算 / 验证完整内容 Hash；
+3. Blob 已具备 Storage Policy 要求的最低可用 Placement；
+4. Attachment 已持久化；
+5. Drive File Revision 已成功提交；
+6. Camera Sync Mapping 已持久化到该 Remote Node / Revision；
+7. 所有上述状态均能通过稳定 ID 重新查询确认。
+
+### 7.3 Photo Projection 不阻塞备份安全
+
+Photo EXIF 解析、Thumbnail、AI、Timeline Projection 失败：
+
+- 不应回滚已安全保存的 Original；
+- 不应把 `BACKUP_VERIFIED` 降级为“文件未备份”；
+- UI 可以显示“已备份，照片处理中 / 索引失败”。
+
+因为 Photo Projection 可重建，而 Original Blob 丢失不可接受。
+
+### 7.4 Free Up Space
+
+客户端只有对 `BACKUP_VERIFIED` 的本地 Asset 才可以提供：
+
+- “释放本地空间”；
+- “删除设备原件，保留 Ikaros 备份”；
+
+之类操作。
+
+执行前客户端仍必须再次确认当前 Mapping 指向的 Revision 没有进入 Missing / Corrupted 等失败状态。
+
+### 7.5 用户删除本地后的状态
+
+本地释放后：
+
+```text
+local_state = REMOVED_AFTER_VERIFIED_BACKUP
+remote_state = BACKUP_VERIFIED
+```
+
+不能将其重新排入“待备份”，也不能显示成 Backup Failure。
+
+---
+
+## 8. Camera Source Availability
+
+### 8.1 Discovered ≠ Original Readable
+
+移动平台可能列出一个 Asset，但 Original 当前并不在本地：
+
+- iCloud Photos 开启优化存储；
+- Android Gallery 展示云端占位内容；
+- Provider 需要联网下载原件；
+- 用户授予 Limited Photos Permission；
+- 原件在可移除存储设备上；
+- Source Provider 临时离线。
+
+因此：
+
+> **发现 Asset 不代表当前 App 一定能读取 Original Bytes。**
+
+### 8.2 Source Item State
+
+Camera Source Item P0 至少允许：
+
+- `READY`；
+- `WAITING_FOR_LOCAL_ORIGINAL`；
+- `PERMISSION_REQUIRED`；
+- `SOURCE_UNAVAILABLE`；
+- `QUEUED`；
+- `BACKUP_VERIFIED`；
+- `IGNORED`；
+- `ERROR`。
+
+`WAITING_FOR_LOCAL_ORIGINAL` 不应按普通网络 Upload Error 无限指数重试。
+
+### 8.3 Limited Permission
+
+当 iOS / Android 权限只允许访问部分媒体时：
+
+- Sync Binding 仍可保持 ACTIVE / DEGRADED；
+- 只备份当前可访问 Asset；
+- 权限扩大后增量发现新增可访问 Asset；
+- 权限缩小不等同于 Remote Delete；
+- 不删除之前已经完成的 Remote Backup。
+
+### 8.4 App 重装
+
+App 重装可能丢失：
+
+- local scope id；
+- local media mapping DB；
+- pending queue。
+
+重新登录后必须允许通过：
+
+- Source Provider stable identifier（若仍可用）；
+- strong content hash；
+- size；
+- capture metadata；
+- Remote Mapping / Backup Manifest；
+
+重建映射，避免把整个 Camera Roll 再次上传为新文件。
+
+---
+
+## 9. Sync Binding 重叠与回环
+
+### 9.1 本地 Scope 重叠
+
+例如：
+
+```text
+Binding A: D:\Photos
+Binding B: D:\Photos\RAW
+```
+
+同一文件可能同时被两个 Binding 观察和上传。
+
+P0 默认：
+
+- 同一 Device 上，不允许两个启用中的 TWO_WAY / UPLOAD 类 Binding 存在本地 Scope 祖先 / 后代重叠；
+- 若平台无法可靠判断 Scope 是否重叠，则要求用户显式确认，并将 Binding 标记为风险配置；
+- CAMERA_ROLL 与普通 Directory Binding 如果底层实际覆盖同一资产集合，也应尽可能提示重复备份风险。
+
+### 9.2 Remote Scope 重叠
+
+以下配置同样危险：
+
+```text
+Binding A local A -> /Documents
+Binding B local B -> /Documents/Projects
+```
+
+尤其两个 Binding 都是 TWO_WAY 时，可能产生重复应用和冲突回环。
+
+P0 默认禁止同一 User / Device 上的可写 Binding Remote Root 祖先 / 后代重叠。
+
+### 9.3 Sync 输出不得再次作为另一个 Binding 输入
+
+客户端必须检测典型回环：
+
+```text
+Download Binding output
+       ↓
+另一个 Upload Binding root
+       ↓
+Remote
+       ↓
+再次 Download
+```
+
+P0 可以通过 Scope 规则直接拒绝；不要求实现复杂的循环图自动求解。
+
+---
+
+## 10. Copy 与 Revision History
+
+### 10.1 File Copy
+
+P0 普通 Copy 语义：
+
+```text
+Source File
+  current revision = rev 8
+       ↓ Copy
+New File Node
+  revision 1 -> same Attachment / Blob
+```
+
+规则：
+
+- 创建新的 Drive Node ID；
+- 新文件从 `revision_no = 1` 开始；
+- 初始 Revision 可以复用 Source 当前 Revision 的 Attachment / Blob；
+- 不复制 Source 的完整 Revision History；
+- `source_kind = COPY`；
+- 可以保存 `copied_from_node_id / copied_from_revision_id` 作为审计来源。
+
+### 10.2 为什么不复制全部历史
+
+Revision History 属于原 File Identity 的历史。
+
+如果普通 Copy 自动复制所有版本：
+
+- 用户难以理解为何新文件创建时就有多年历史；
+- Retention / Quota 语义复杂；
+- 后续两个文件历史分叉难解释；
+- 大目录复制会放大数据库元数据。
+
+需要完整历史克隆的场景未来应使用独立 `Clone With History` 能力，而不是普通 Copy。
+
+### 10.3 Folder Copy
+
+Folder Copy 对每个 File Node 应遵守同样规则：
+
+- 新 Node；
+- revision 1；
+- 复用当前 Attachment / Blob；
+- 不复制历史 Revision。
+
+---
+
+## 11. 跨平台文件系统 P0 语义
+
+### 11.1 目标
+
+P0 Drive Sync 目标是：
+
+> 在主流 Windows / macOS / Linux / Mobile 文件系统之间可靠同步“用户文件内容 + 基础组织元数据”。
+
+它不是完整 POSIX filesystem clone。
+
+### 11.2 名称规范化
+
+服务端应定义统一 canonical / normalized name 规则，并至少处理：
+
+- Unicode normalization；
+- case collision；
+- trailing space；
+- trailing dot；
+- `/`、`\` 等路径分隔符；
+- Windows reserved names，例如 `CON`、`PRN`、`AUX`、`NUL`、`COM1` 等；
+- 最大文件名长度；
+- 服务端最大 Path Depth / Logical Path Length。
+
+### 11.3 Case-only Rename
+
+例如：
+
+```text
+readme.md -> README.md
+```
+
+在大小写不敏感文件系统上可能无法直接原子完成。
+
+客户端可以使用临时中间名：
+
+```text
+readme.md
+  ↓
+.__ikaros_tmp_xxx
+  ↓
+README.md
+```
+
+但 Remote Node Identity 不变，只产生一次 Logical Rename。
+
+### 11.4 P0 不保证完整同步的元数据
+
+P0 不承诺跨平台完整保留：
+
+- POSIX uid / gid；
+- ACL 全语义；
+- executable bit；
+- Windows ADS；
+- macOS resource fork；
+- arbitrary xattr；
+- device file；
+- socket；
+- FIFO。
+
+普通文件内容、目录结构、文件名、基础时间 Hint 是 P0 核心。
+
+### 11.5 Hard Link
+
+P0 不把 Hard Link 关系提升为 Drive 领域语义。
+
+两个本地 hard link 可以：
+
+- 因内容相同而复用同一 Blob；
+- 但在 Drive 中仍是两个 File Node。
+
+### 11.6 Symlink
+
+继续遵守主设计：默认不跟随 Root 外部 Target。
+
+P0 可以直接忽略 Symlink，或将其记录为 Unsupported / Ignored；不得误将目标内容静默复制到另一个路径后声称“Symlink 已同步”。
+
+---
+
+## 12. Shared Folder 与 TWO_WAY Sync
+
+### 12.1 P0 默认限制
+
+P0 推荐：
+
+> **只有当前用户拥有写控制权的 Personal Drive Folder 才能作为 TWO_WAY Sync Root。**
+
+`Shared With Me` 虚拟入口不能直接作为 Sync Root。
+
+### 12.2 原因
+
+共享目录会引入：
+
+- Owner 随时撤销权限；
+- Read / Write Permission 动态变化；
+- Share Scope 被移动或删除；
+- 目标用户并不拥有 Trash / Restore 最终控制权；
+- Folder ACL 继承变化；
+- Owner 与 Guest 同时编辑时的额外冲突来源。
+
+这会把 P0 文件同步状态机和授权状态机强耦合。
+
+### 12.3 P0 可支持只读下载
+
+如果产品需要，可以允许：
+
+```text
+Shared Folder
+   ↓
+DOWNLOAD_ONLY Binding
+```
+
+但每次 Pull / Download 必须重新经过当前 ACL 检查。
+
+权限撤销后：
+
+- 停止未来同步；
+- Binding 进入 `AUTH_REQUIRED / PERMISSION_REVOKED`；
+- 已下载本地文件如何处置遵守 Offline / Security Policy；
+- 不尝试把本地修改 Push 回已失去权限的 Shared Folder。
+
+### 12.4 P1 再开放 Shared TWO_WAY
+
+等权限撤销、Shared Tombstone、Owner / Guest Conflict、Offline Permission Snapshot 等行为有完整测试后，再考虑 Shared Folder TWO_WAY。
+
+---
+
+## 13. API / Command 补充
+
+主设计已有 Drive Query / Command。本补充要求以下契约显式表达版本和状态。
+
+### 13.1 Mutation Preconditions
+
+修改现有 Node 的 Command 应至少支持：
+
+- expected node version；
+- expected current revision id（内容写入时）；
+- operation / idempotency id；
+- actor / device context。
+
+例如逻辑语义：
+
+```text
+ReplaceFile(
+  node_id,
+  expected_node_version,
+  base_revision_id,
+  upload_session_id,
+  operation_id
+)
+```
+
+### 13.2 Pull Drive Changes
+
+至少需要表达：
+
+```text
+PullChanges(
+  drive_space_id,
+  cursor,
+  limit
+)
+```
+
+返回：
+
+- ordered Change；
+- next cursor；
+- has more；
+- cursor expired / full resync required；
+- contract version。
+
+### 13.3 Backup Status Query
+
+客户端需要能通过稳定 ID 查询某个 Camera Asset 对应的 Remote Backup 状态：
+
+- upload state；
+- verification state；
+- Drive Node / Revision；
+- Blob availability；
+- Photo Projection state。
+
+客户端不得只能依赖本地“我记得上传过”的 Boolean。
+
+### 13.4 Quota
+
+Begin Upload 返回：
+
+- reserved bytes；
+- reservation id；
+- reservation expires_at；
+- effective logical quota snapshot。
+
+Finalize / Abort 应显式结算 Reservation。
+
+---
+
+## 14. 数据库补充
+
+主设计中的 Drive Schema 可以增加或吸收以下概念：
+
+```text
+drive_change_log
+  - drive_space_id
+  - sequence
+  - node_id
+  - mutation_kind
+  - node_version
+  - revision_id
+
+drive_quota_reservation
+  - upload_session_id
+  - reserved_bytes
+  - state
+  - expires_at
+
+drive_camera_backup_mapping
+  - binding_id
+  - source_item_id
+  - remote_node_id
+  - remote_revision_id
+  - verification_state
+  - source_state
+```
+
+这些可以根据最终实现合并进现有表或 Projection，不要求机械一概建成三张独立表；但相应语义必须有持久化真相，不能仅存在客户端内存中。
+
+### 14.1 Change Log Retention
+
+Drive Change Log 可以压缩 / 清理，但必须与 Sync Cursor Retention 协调。
+
+如果设备 Cursor 早于最老可重放 Sequence：
+
+```text
+FULL_RESYNC_REQUIRED
+```
+
+不能返回“空变化”误导客户端认为已同步。
+
+### 14.2 Quota Reservation Reaper
+
+过期 Reservation 由后台任务安全释放。
+
+Reaper 必须幂等，且不能释放已经成功 Finalize / Commit 的 Reservation。
+
+---
+
+## 15. P0 验收不变量
+
+进入 P0 实现与测试前，至少应将以下行为写成 Integration / E2E 场景：
+
+1. Rename / Move 后 Node ID 不变，客户端不重新上传相同字节。
+2. Trash seq 20、Restore seq 21 后，长期离线客户端最终为 ACTIVE，不被旧 Tombstone 再删。
+3. Purged Node 不因旧设备重新上线而复活。
+4. 两设备基于同一 Revision 同时写入时产生 Conflict Copy，不丢任何一方字节。
+5. Office atomic replace 保存只产生一个有效新 Revision，不产生无意义 Trash + Create。
+6. Upload Session 并发时 Quota Reservation 阻止超额承诺。
+7. Upload Abort / Expire 后 Reservation 最终释放。
+8. Camera Upload HTTP 成功但 Blob 验证失败时，不允许 Free Up Space。
+9. Photo Projection 失败但 Original `BACKUP_VERIFIED` 时，仍可视为文件备份成功。
+10. 本地删除 `BACKUP_VERIFIED` Camera Asset 不删除 Remote Backup。
+11. iCloud / cloud-only Asset 无本地 Original 时进入 Waiting 状态，不无限报 Upload Error。
+12. App 重装后 Full Resync 能通过 Hash / Mapping 重建，避免全量重复上传。
+13. 重叠的 TWO_WAY Binding 被拒绝或明确标记风险，不产生同步回环。
+14. File Copy 只复制 Current Revision 为新文件 rev 1，不复制完整历史。
+15. `readme.md -> README.md` 在大小写不敏感平台上仍表现为同一个 Remote Node Rename。
+16. Shared Folder P0 不允许 TWO_WAY Push；权限撤销后 Download-only Binding 停止同步。
+17. Cursor 落后 Change Log Retention 时明确返回 Full Resync Required。
+18. 重试同一 Operation ID 不重复创建 Revision、Conflict Copy 或 Reservation。
+
+---
+
+## 16. 结论
+
+P0 Drive Sync 的最终一致性骨架应为：
+
+```text
+Local Watcher / Source Provider
+          ↓ hint only
+Change Coalescing / Reconcile
+          ↓
+Logical Local Delta
+          ↓
+Drive Command + Preconditions
+          ↓
+Drive Transaction
+   ├── Node / Revision
+   ├── Change Sequence
+   └── Outbox Event
+          ↓
+Sync Change Feed
+          ↓
+Other Devices
+```
+
+Camera Backup 的安全骨架应为：
+
+```text
+Source Asset Discovered
+      ↓
+Original Readable?
+   ├── no -> WAITING / PERMISSION / SOURCE_UNAVAILABLE
+   └── yes
+        ↓
+     Upload
+        ↓
+   Blob Verified
+        ↓
+   Drive Committed
+        ↓
+ Mapping Persisted
+        ↓
+ BACKUP_VERIFIED
+        ├── Photo Projection
+        └── Free Up Space Eligible
+```
+
+因此 P0 不追求“所有 watcher event 都立即同步”，而追求：
+
+> **每一次最终提交都可解释、可重放、可验证；删除与恢复不会因离线设备乱序而误删；备份只有在服务端真正持久化并验证后才允许用户释放唯一的本地原件。**

--- a/docs/v2/Personal-Drive-File-Synchronization-Subsystem-Design.md
+++ b/docs/v2/Personal-Drive-File-Synchronization-Subsystem-Design.md
@@ -1,0 +1,1746 @@
+# Ikaros V2 Personal Drive / File Synchronization 子系统设计
+
+| 项目 | 内容 |
+|---|---|
+| 文档名称 | Ikaros V2 Personal Drive / File Synchronization 子系统设计 |
+| 适用版本 | Ikaros V2 |
+| 文档版本 | v0.1 |
+| 编写日期 | 2026-08-31 |
+| 状态 | 草案（Draft） |
+| 产品基线 | `Product-Requirements-Document.md` |
+| 系统基线 | `System-Overview-Design.md` |
+| API 基线 | `API-Convention-Design.md` |
+| 数据库基线 | `Database-Overview-Design.md` |
+| 依赖设计 | `Attachment-Blob-Storage-Subsystem-Design.md`、`Offline-Cache-Device-Synchronization-Subsystem-Design.md`、`Content-Ingestion-Metadata-Synchronization-Subsystem-Design.md`、`Photo-Album-Image-Asset-Subsystem-Design.md`、`Sharing-Collaboration-Room-Subsystem-Design.md`、`Background-Task-Scheduler-Design.md` |
+
+> 本文档定义 Ikaros V2 的个人网盘、文件树、文件版本、上传下载、回收站、目录同步、移动端照片 / 视频自动备份、跨设备文件同步、冲突处理与分享集成。
+>
+> 本子系统提供的是“用户可理解的文件空间与同步语义”。实际字节仍由 Attachment / Blob / Storage 保存；设备级可靠传输、游标与 Pending Mutation 继续复用 Offline / Device Synchronization；图片的 EXIF、Timeline、Album 等专业语义仍由 Photo 子系统拥有。
+
+---
+
+## 1. 设计目标
+
+Personal Drive 子系统需要同时覆盖传统个人网盘与现代设备同步场景：
+
+1. 提供类似个人网盘的文件 / 文件夹树、上传、下载、移动、复制、重命名、搜索、收藏与回收站。
+2. 支持桌面端 / 移动端将一个或多个本地目录持续同步到 Ikaros。
+3. 支持类似 Immich 的手机照片 / 视频自动备份，包含后台增量上传、断点续传、去重和已备份状态。
+4. 允许“上传到网盘”与“进入专业内容库”分离，同时为照片、视频、文档等内容提供可选的领域投影。
+5. 支持文件不可变 Revision，使覆盖写、历史版本、恢复和同步冲突均可解释。
+6. 支持单向备份、双向同步、仅下载等不同同步模式，而不是把所有场景强制为双向同步。
+7. 支持大文件、弱网络、移动网络、后台受限环境下的分片 / 可恢复上传。
+8. 支持 rename / move 检测，尽量避免把路径变化错误识别成“删除 + 重新上传”。
+9. 支持同步冲突显式保留，禁止静默丢失任一端用户数据。
+10. 支持多用户、ACL 与 Share，但文件树的拥有关系、共享访问与物理存储隔离必须分离。
+11. 保持自托管优先：单机 + PostgreSQL + 本地文件系统即可落地，S3 / NAS / 多副本是可选扩展。
+12. 任何删除、版本清理和物理 GC 都必须与 Blob Storage 的保守删除原则一致。
+
+核心原则：
+
+> **Drive Path 是用户组织语义，不是内容身份；File Revision 是文件内容历史，不是 Blob 的可变写入；同步负责保持副本收敛，但不能通过静默覆盖来伪造“无冲突”。**
+
+---
+
+## 2. 范围与非目标
+
+### 2.1 本子系统负责
+
+- Personal Drive Space；
+- File / Folder Tree；
+- Drive Node；
+- 文件名、父目录、路径投影与排序；
+- File Revision / Revision History；
+- 文件上传、续传、替换与版本恢复；
+- 文件 / 文件夹移动、复制、重命名；
+- Trash / Restore / Permanent Delete 请求；
+- Drive Quota / Logical Usage Projection；
+- Sync Binding；
+- Sync Mode / Direction / Filter；
+- Local File Identity / Remote Node Mapping；
+- 增量扫描与变化检测；
+- 手机相册 / 相机胶卷自动备份；
+- Sync Conflict 与 Conflict Copy；
+- 同步状态、错误、重试、Pause / Resume；
+- Drive 与 Share / ACL 的交接；
+- Drive 与 Photo / Media / Document 等专业领域的投影交接；
+- Drive Event / Command / Query 契约；
+- Drive 自有 PostgreSQL Schema 的概念边界。
+
+### 2.2 本子系统不负责
+
+- Blob Placement、Storage Provider、多副本和 Archive 的物理实现；
+- 通用 Device Registration、Sync Cursor Runtime 与 Pending Mutation Envelope；
+- Photo 的 EXIF、GPS、Timeline、Album、Thumbnail / Preview 专业模型；
+- Media 的播放版本、转码与字幕模型；
+- Document Revision / Collaborative Editing；
+- OS 文件监听 API 的唯一技术选型；
+- iOS / Android 后台任务机制的具体实现；
+- WebDAV / SMB / SFTP 的最终协议实现；
+- 跨 Ikaros Instance Federation；
+- 企业级多人协作盘、部门盘与复杂租户模型。
+
+---
+
+## 3. 与现有 V2 子系统的边界
+
+### 3.1 Attachment / Blob / Storage
+
+Drive 不保存物理路径、Bucket、Object Key 或 Provider URL 作为文件身份。
+
+```text
+Drive File Node
+      ↓ 当前 Revision
+File Revision
+      ↓
+Attachment
+      ↓
+Blob
+      ↓
+Placement / Storage Provider
+```
+
+同一个 Blob 可以被多个 Drive File Revision 或其他业务 Attachment 引用；物理去重由 Storage 负责。
+
+### 3.2 Offline / Device Synchronization
+
+Offline / Device Sync 负责：
+
+- Device；
+- Sync Cursor；
+- Change Feed；
+- Pending Mutation；
+- Tombstone 传播；
+- Client Operation ID；
+- 通用可靠传输和重试。
+
+Drive 负责：
+
+- 文件树领域事实；
+- 文件 Revision；
+- 路径变更语义；
+- Sync Binding；
+- 文件级冲突判定；
+- 本地文件与 Remote Node 映射；
+- 同步策略。
+
+因此：
+
+> **Offline Sync Runtime ≠ Drive File Synchronizer。前者提供可靠同步基础设施，后者定义文件同步的业务语义。**
+
+### 3.3 Content Ingestion
+
+Content Ingestion 解决“外部 Source 中的内容如何被发现并导入 Ikaros 的 Resource 体系”。
+
+Drive Sync 解决“某个用户明确绑定的本地目录 / 相册如何持续和远端文件空间收敛”。
+
+两者可以共享 Fingerprint、Probe、Background Task 等能力，但不应复用成一个模糊的万能 Scanner。
+
+### 3.4 Photo 子系统
+
+手机照片备份必须同时满足两种用户视角：
+
+```text
+文件视角：Drive 中存在原始文件
+          +
+照片视角：Photos 中存在 Photo Resource / Timeline / EXIF
+```
+
+推荐流程：
+
+```text
+Device Camera Roll
+      ↓ backup
+Drive File Revision / Attachment
+      ↓ domain projection
+Photo Resource + Original Asset
+```
+
+Drive 拥有“文件已备份到哪个目录、同步状态是什么”；Photo 拥有“这是一张什么照片、拍摄时间、EXIF、Album、Preview”。
+
+不能为了照片体验绕过 Drive / Storage 直接保存一套独立原图字节。
+
+### 3.5 Sharing
+
+Share 不改变 Drive Node 的拥有者，也不创建第二份文件。
+
+Share 只是对 File / Folder Scope 的授权入口，最终访问仍必须经过 ACL / Permission。
+
+---
+
+## 4. 核心不变量
+
+1. **Drive Node ID ≠ Path**：File / Folder 使用 UUIDv7，路径只是由父子关系和名称推导的用户视图。
+2. **File Revision 不可变**：已提交 Revision 的 Attachment / Blob 不得原地改写。
+3. **覆盖写创建新 Revision**：用户“替换文件”不能修改旧 Blob。
+4. **Folder 不持有 Blob**：目录只是组织节点。
+5. **移动 / 重命名不改变 File Identity**：只修改组织关系，不创建新文件内容。
+6. **同名限制由父目录作用域决定**：同一父目录下默认禁止两个 ACTIVE Node 使用相同规范化名称。
+7. **删除进入 Trash 不等于 Blob GC**：Trash、Revision Retention 与物理删除完全分离。
+8. **本地路径不是服务端身份**：不同设备上的 `D:\Photos` 与 `/Users/a/Pictures` 可以映射到同一个 Remote Folder。
+9. **同步不能静默丢数据**：无法安全合并的双端修改必须产生显式 Conflict。
+10. **单向 Backup 不传播远端删除到本地**：除非用户明确启用对应危险策略。
+11. **照片已上传 ≠ 已完成 Photo 入库**：Drive Backup Success 与 Photo Projection Success 分别可观测。
+12. **客户端成功 Hash ≠ 服务端最终完整性确认**：服务端仍按 Storage 规则验证 Blob。
+13. **物理去重 ≠ 业务合并**：相同 Blob 的两个 Drive File 可以保持不同名称、目录和生命周期。
+14. **Sync Cursor 不能依赖本地时间**：使用服务端稳定游标 / Revision Token。
+15. **Conflict Copy 不能覆盖原节点**：冲突副本必须保留可追踪来源。
+16. **Root / Special Folder 是稳定身份**：不能依赖显示名称识别 Camera Uploads、Trash 等系统语义。
+
+---
+
+## 5. 领域模型总览
+
+```text
+User
+ └── Drive Space
+      ├── Root Folder
+      │    ├── Folder Node
+      │    │    ├── File Node
+      │    │    │    └── File Revisions
+      │    │    └── Folder Node
+      │    └── File Node
+      ├── Trash Scope
+      └── Special Folders
+
+Device
+ └── Sync Binding
+      ├── Local Root / Camera Roll
+      ├── Remote Folder
+      ├── Mode / Policy
+      ├── Sync Cursor
+      └── Item Mappings
+
+Local Item ↔ Drive Node
+          ↓
+   Sync Item State
+          ↓
+ Conflict / Retry / Tombstone
+```
+
+---
+
+## 6. Drive Space
+
+Drive Space 表示一个用户可管理的个人文件空间。
+
+V2 P0 推荐：
+
+- 每个 User 至少拥有一个 Personal Drive Space；
+- 一个用户未来可以扩展多个 Space，例如 Personal / Archive；
+- 不把 Drive Space 等同于 Storage Provider 或 Bucket；
+- Storage Policy 决定其字节落到哪里，但用户不需要知道 Provider Object Key。
+
+建议字段：
+
+```text
+DriveSpace
+├── id: uuid / UUIDv7
+├── owner_user_id: uuid
+├── display_name: text
+├── root_node_id: uuid
+├── default_storage_policy_id: uuid?
+├── quota_policy_id: uuid?
+├── state: ACTIVE | READ_ONLY | DISABLED
+├── created_at: timestamptz
+├── updated_at: timestamptz
+└── version: bigint
+```
+
+### 6.1 Personal Space 与共享文件
+
+共享给用户的文件默认不复制进其 Personal Space。
+
+客户端可以提供虚拟入口：
+
+- My Drive；
+- Shared With Me；
+- Recent；
+- Favorites；
+- Photos；
+- Trash。
+
+其中 `Shared With Me`、`Recent`、`Favorites` 多数是 Query / Projection，不是物理目录。
+
+---
+
+## 7. Drive Node
+
+Drive Node 是文件树的稳定组织实体。
+
+类型：
+
+- `FILE`；
+- `FOLDER`。
+
+建议公共字段：
+
+```text
+DriveNode
+├── id: uuid / UUIDv7
+├── drive_space_id: uuid
+├── parent_id: uuid?
+├── node_type: FILE | FOLDER
+├── name: text
+├── normalized_name: text
+├── lifecycle: ACTIVE | TRASHED | PURGED
+├── created_by: uuid
+├── created_at: timestamptz
+├── updated_at: timestamptz
+├── trashed_at: timestamptz?
+└── version: bigint
+```
+
+### 7.1 Path 是投影
+
+路径：
+
+```text
+/Documents/Project/spec.pdf
+```
+
+来自：
+
+```text
+Root -> Documents -> Project -> spec.pdf
+```
+
+Path 可以缓存用于查询优化，但不得成为实体主键或跨领域引用。
+
+### 7.2 名称规范化
+
+需要显式定义：
+
+- Unicode normalization；
+- 大小写敏感策略；
+- 禁止名称；
+- 尾随空格 / 点；
+- Windows / macOS / Linux 跨平台兼容；
+- 最大名称长度。
+
+服务端应拥有统一规范化规则，否则 Windows 与 Linux 客户端可能产生不可收敛的名称冲突。
+
+V2 推荐以“跨平台最小公分母”作为 P0 规则，并允许客户端在上传前预检。
+
+### 7.3 同目录唯一性
+
+推荐约束：
+
+```text
+UNIQUE(drive_space_id, parent_id, normalized_name)
+WHERE lifecycle = 'ACTIVE'
+```
+
+Trash 中历史同名节点不阻止用户创建新的 Active Node。
+
+---
+
+## 8. File Node 与 File Revision
+
+File Node 表示“用户认为是同一个文件槽位”的稳定身份。
+
+File Revision 表示这个文件在某一时刻的不可变内容版本。
+
+```text
+File Node
+├── current_revision_id
+└── Revision History
+     ├── rev 1 -> Attachment A -> Blob A
+     ├── rev 2 -> Attachment B -> Blob B
+     └── rev 3 -> Attachment C -> Blob C
+```
+
+建议字段：
+
+```text
+DriveFileRevision
+├── id: uuid / UUIDv7
+├── file_node_id: uuid
+├── revision_no: bigint
+├── attachment_id: uuid
+├── content_hash: text?  # 可作为冗余查询字段，不替代 Blob 真相
+├── size: bigint
+├── media_type: text?
+├── source_kind: UPLOAD | SYNC | COPY | RESTORE | IMPORT
+├── source_device_id: uuid?
+├── base_revision_id: uuid?
+├── created_by: uuid
+├── created_at: timestamptz
+└── metadata: jsonb?
+```
+
+### 8.1 Revision Number
+
+`revision_no` 只在单个 File Node 内单调增长。
+
+它不是全局 ID，也不替代 UUIDv7。
+
+### 8.2 乐观并发
+
+更新现有 File 时，客户端必须携带它认为的 `base_revision_id` 或 ETag。
+
+若服务端当前 Revision 已改变，则不能直接覆盖，应：
+
+- 返回 Conflict；或
+- 根据 Sync Policy 生成 Conflict Copy。
+
+---
+
+## 9. 文件操作语义
+
+### 9.1 Create Folder
+
+创建 Folder 只产生 Drive Node，不创建 Attachment / Blob。
+
+### 9.2 Upload New File
+
+```text
+Create Upload Session
+      ↓
+Upload bytes / chunks
+      ↓
+Finalize Blob / Attachment
+      ↓
+Create File Node
+      ↓
+Create Revision 1
+```
+
+### 9.3 Replace File
+
+```text
+Existing File Node
+      ↓ upload new bytes
+New Attachment / Blob
+      ↓
+New File Revision
+      ↓
+CAS current_revision_id
+```
+
+旧 Revision 保留到 Retention Policy 决定是否清理。
+
+### 9.4 Rename / Move
+
+Rename / Move 只修改：
+
+- `name`；
+- `parent_id`。
+
+不得创建新 Blob，也不应创建新 File Revision。
+
+### 9.5 Copy
+
+Copy 默认创建新的 Drive Node，但可以让初始 Revision 引用同一个 Attachment / Blob。
+
+因此逻辑复制可以做到 O(1) 元数据复制，Storage 无需复制字节。
+
+后续任一副本被替换时生成自己的新 Revision，不影响另一副本。
+
+### 9.6 Folder Copy
+
+大型目录复制必须作为 Background Task，并支持：
+
+- 进度；
+- 部分失败；
+- Cancel；
+- 幂等；
+- 冲突策略。
+
+---
+
+## 10. 上传协议
+
+### 10.1 小文件
+
+小文件可以使用单请求 Upload，但最终仍应经过统一 Ingest / Finalize 语义。
+
+### 10.2 大文件 / 弱网络
+
+必须支持 resumable upload：
+
+```text
+Upload Session
+├── expected size
+├── optional expected hash
+├── chunk policy
+├── received ranges / parts
+├── expires_at
+├── actor / device
+└── target intent
+```
+
+推荐允许实现：
+
+- multipart；
+- chunked upload；
+- content-range；
+- S3 multipart delegation。
+
+具体传输协议可以后续在 API 设计中确定，但业务语义统一为 Upload Session。
+
+### 10.3 Finalize
+
+Finalize 前需要：
+
+- 校验上传完整性；
+- 计算 / 验证内容摘要；
+- 创建或复用 Blob；
+- 创建 Attachment；
+- 原子提交 Drive Revision。
+
+若字节上传成功但 Drive Revision 提交失败，必须允许清理孤立临时对象或通过后台 Reconcile 回收。
+
+### 10.4 秒传 / 去重
+
+客户端可以先提交 Hash Hint 询问服务端是否已有可复用 Blob，但：
+
+- 必须经过当前用户的授权语义；
+- 服务端不能通过“是否命中 Hash”泄露其他用户私有文件存在性；
+- 即使命中 Blob，也仍需创建新的业务 Attachment / Revision。
+
+---
+
+## 11. 下载与预览
+
+Drive 下载复用 Storage 的授权下载、Range、Restore、Cache 能力。
+
+客户端只处理用户语义：
+
+- Available；
+- Remote；
+- Restoring；
+- Temporarily Unavailable；
+- Missing / Corrupted。
+
+不直接展示 Object Key。
+
+对于可预览内容：
+
+- 图片使用 Photo Preview / Thumbnail；
+- 视频可使用 Media Playback Variant；
+- 文档可使用 Document / Preview Artifact；
+- 未知文件至少支持原始下载。
+
+Drive 本身不重复实现所有格式预览器。
+
+---
+
+## 12. Trash / Restore / Permanent Delete
+
+### 12.1 Trash
+
+删除 File / Folder 默认进入 Trash。
+
+Folder 进入 Trash 时，其后代节点保持树关系，以便整体 Restore。
+
+需要记录：
+
+- original parent；
+- trashed_at；
+- actor；
+- optional deletion reason。
+
+### 12.2 Restore
+
+恢复时若原父目录仍存在且名称不冲突，则恢复原位置。
+
+若冲突：
+
+- 返回冲突供用户选择；或
+- 根据策略自动重命名，例如 `file (restored).txt`。
+
+### 12.3 Permanent Delete
+
+Permanent Delete 是高风险动作。
+
+它只删除 Drive 业务引用 / Revision 保留资格，不能直接承诺立即删除 Blob 字节。
+
+Blob 是否可 GC 仍由 Storage 判断：
+
+- 是否还有其他 Attachment 引用；
+- 是否有 Retention Hold；
+- 是否有 Revision Retention；
+- 是否有 Share / Export / Backup 相关保留规则。
+
+---
+
+## 13. Revision Retention
+
+Drive 可提供版本历史策略：
+
+- 保留最近 N 个 Revision；
+- 保留最近 N 天；
+- 手动 Pin Revision；
+- 永久保留（可选）；
+- 配额压力下自动清理未 Pin 的旧 Revision。
+
+清理旧 Revision 时只释放业务引用，不直接删除 Blob Placement。
+
+版本恢复采用：
+
+> **从历史 Revision 创建一个新的当前 Revision。**
+
+不得通过把 `current_revision_id` 简单指回旧记录来伪造时间历史，否则后续审计和同步顺序会变得不清晰。
+
+---
+
+## 14. Sync Binding
+
+Sync Binding 表示：
+
+> “某个设备上的一个本地 Scope，按某种策略，与某个 Drive Folder 持续同步。”
+
+建议字段：
+
+```text
+SyncBinding
+├── id: uuid / UUIDv7
+├── user_id: uuid
+├── device_id: uuid
+├── drive_space_id: uuid
+├── remote_root_node_id: uuid
+├── local_scope_id: stable client-generated id
+├── local_display_path: protected text?
+├── source_kind: DIRECTORY | CAMERA_ROLL | MEDIA_COLLECTION
+├── mode: BACKUP | TWO_WAY | UPLOAD_ONLY | DOWNLOAD_ONLY
+├── delete_policy
+├── conflict_policy
+├── network_policy
+├── include_rules
+├── exclude_rules
+├── enabled: boolean
+├── state
+├── created_at
+└── updated_at
+```
+
+### 14.1 Local Scope Identity
+
+服务端不能把绝对本地路径当作 Binding 身份。
+
+客户端应生成稳定 `local_scope_id`。
+
+原因：
+
+- 用户可能重命名本地目录；
+- Windows Drive Letter 变化；
+- Android SAF URI 变化；
+- macOS Sandbox Bookmark；
+- 路径可能包含隐私信息。
+
+`local_display_path` 只用于用户诊断，按 Private / Sensitive 数据处理。
+
+---
+
+## 15. Sync Mode
+
+### 15.1 BACKUP
+
+适用于手机照片、工作资料备份等场景。
+
+语义：
+
+- 本地新增 / 修改上传到服务端；
+- 服务端不会主动删除本地文件；
+- 服务端重命名 / 移动默认不强制回写本地；
+- 本地删除默认不删除云端已备份内容；
+- 可选“本地删除后保留云端”是默认安全行为。
+
+### 15.2 UPLOAD_ONLY
+
+持续上传本地变更，但比 BACKUP 更接近目录镜像，可配置是否传播本地删除。
+
+### 15.3 DOWNLOAD_ONLY
+
+服务端为权威端，本地保持一个镜像副本。
+
+### 15.4 TWO_WAY
+
+双向同步：
+
+- 本地增删改 → Remote；
+- Remote 增删改 → Local；
+- 必须有 Conflict Detection；
+- 必须有 Tombstone；
+- 不能仅靠文件修改时间解决冲突。
+
+---
+
+## 16. Sync Item Mapping
+
+为了识别 rename / move，客户端与服务端需要维护稳定映射，而不能每次只比较路径。
+
+建议概念：
+
+```text
+SyncItemMapping
+├── binding_id
+├── local_item_id
+├── remote_node_id
+├── local_parent_id?
+├── last_synced_revision_id?
+├── last_synced_fingerprint?
+├── last_seen_local_metadata
+├── last_seen_remote_version
+├── state
+└── updated_at
+```
+
+### 16.1 Local Item ID
+
+不同平台实现可以不同：
+
+- 文件系统 inode / file id + volume identity（可用时）；
+- Android MediaStore ID；
+- iOS Photos local identifier；
+- 客户端持久化 sidecar mapping；
+- 内容 + 元数据组合弱标识。
+
+任何单一平台 ID 都不能成为 Drive Node 的全局主键。
+
+### 16.2 Rename / Move Detection
+
+优先信号：
+
+1. stable local item id；
+2. previous mapping；
+3. strong content hash；
+4. size + weak fingerprint；
+5. path heuristic。
+
+只有足够可信时才自动视为 rename / move。
+
+否则宁可产生新文件并保留旧 Tombstone，也不要错误地把两个不同文件合并。
+
+---
+
+## 17. 增量同步流程
+
+典型双向同步：
+
+```text
+Local Scan / OS Change Journal
+        ↓
+Local Delta
+        ↓
+Compare with Mapping + Last Synced Revision
+        ↓
+Push Mutations
+        ↓
+Drive Commands
+        ↓
+Server Change Feed / Cursor
+        ↓
+Pull Remote Delta
+        ↓
+Apply to Local
+        ↓
+Persist Mapping / Checkpoint
+```
+
+关键要求：
+
+- 每项 Mutation 有稳定 Operation ID；
+- Batch 部分失败可单项重试；
+- Cursor 只在已安全应用到本地后推进；
+- 客户端崩溃后可从 Checkpoint 恢复；
+- 重复 Push 不产生重复 Revision；
+- 重复 Pull 不重复创建本地文件。
+
+---
+
+## 18. 文件变化检测
+
+变化检测分层：
+
+### 18.1 快速元数据阶段
+
+使用：
+
+- local item id；
+- size；
+- mtime；
+- directory entry generation；
+- OS change journal / MediaStore change token。
+
+这一步只用于发现候选变化。
+
+### 18.2 Fingerprint 阶段
+
+对疑似变化计算：
+
+- fast fingerprint；
+- partial hash；
+- full cryptographic hash（必要时）。
+
+`mtime + size` 不能作为最终内容身份。
+
+### 18.3 大文件优化
+
+对于超大文件：
+
+- 先比较 stable item id / size / metadata；
+- 必要时使用分块 hash；
+- 最终上传完整性仍由 Blob Hash 保证。
+
+---
+
+## 19. Sync Conflict
+
+### 19.1 冲突定义
+
+如果双方都基于同一个 `last_synced_revision` 独立产生了新内容，则是内容冲突。
+
+例如：
+
+```text
+Remote rev 10
+  ↙       ↘
+Local A   Remote B
+```
+
+不能靠“谁的 mtime 新”自动覆盖。
+
+### 19.2 默认策略
+
+P0 推荐：
+
+- 保留 Remote 当前文件；
+- 将 Local 上传为 Conflict Copy；
+- Conflict Copy 与原 File 建立关联；
+- 文件名包含设备 / 时间等可读后缀；
+- UI 提示用户人工合并。
+
+例如：
+
+```text
+report.docx
+report (conflict from Laptop 2026-08-31).docx
+```
+
+命名只是展示策略，真正关联通过 Conflict Record。
+
+### 19.3 Conflict Record
+
+建议字段：
+
+- id；
+- binding_id；
+- original_node_id；
+- conflicting_node_id / revision_id；
+- base_revision_id；
+- source_device_id；
+- detected_at；
+- state: OPEN | RESOLVED | DISMISSED；
+- resolution；
+- resolved_at；
+- resolved_by。
+
+### 19.4 Metadata Conflict
+
+重命名 / 移动也可能冲突，例如：
+
+- Device A rename `a.txt -> b.txt`；
+- Device B move `a.txt` 到另一个目录。
+
+P0 可以使用保守规则：
+
+- 内容变化优先保留；
+- 无损组织操作尽量自动重放；
+- 无法确定顺序时产生 Metadata Conflict。
+
+---
+
+## 20. 删除同步与 Tombstone
+
+删除传播必须有稳定 Tombstone。
+
+Drive Tombstone 至少包含：
+
+- node id；
+- deletion generation / sequence；
+- deleted_at；
+- actor / device；
+- previous parent；
+- previous name；
+- retention deadline。
+
+### 20.1 BACKUP 默认删除策略
+
+手机照片 Backup：
+
+> 本地删除默认不删除 Ikaros 中已备份文件。
+
+这是备份与同步最重要的区别之一。
+
+可以未来提供：
+
+- “仅备份新增内容”；
+- “本地释放空间但保留云端”；
+- “同步删除”高级危险开关。
+
+### 20.2 TWO_WAY 删除策略
+
+双向同步中删除可以传播，但必须：
+
+- 进入 Trash，而不是直接 Purge；
+- 保留 Tombstone；
+- 对长期离线设备保证删除不会复活；
+- Cursor 太旧时要求 Full Resync。
+
+---
+
+## 21. 手机照片 / 视频自动备份
+
+这是 Drive Sync 的专用策略，不是独立第二套上传系统。
+
+### 21.1 Source
+
+支持：
+
+- iOS Photos Library；
+- Android MediaStore；
+- 用户选择的 Camera / Screenshots / WhatsApp 等媒体集合；
+- 未来其他本地媒体集合。
+
+### 21.2 Backup Binding
+
+Photo Backup Binding 默认：
+
+```text
+source_kind = CAMERA_ROLL
+mode = BACKUP
+delete_policy = KEEP_REMOTE
+conflict_policy = PRESERVE_BOTH
+```
+
+默认 Remote 目标可以是系统 Special Folder，例如：
+
+```text
+/Photos/Camera Uploads/{device-name}/
+```
+
+但服务端用 Special Folder ID 识别语义，不依赖这个显示路径。
+
+### 21.3 增量发现
+
+客户端应优先使用平台增量能力：
+
+- Photos change token；
+- MediaStore generation / query；
+- persisted local media identity。
+
+首次启用允许：
+
+- 仅从现在开始；
+- 备份最近 N 天；
+- 备份全部历史。
+
+### 21.4 已备份判定
+
+不能只以文件名判断。
+
+至少组合：
+
+- local media id；
+- source library identity；
+- content fingerprint；
+- server mapping；
+- optional asset resource identifier。
+
+### 21.5 HEIC / RAW / Live Photo
+
+原则：
+
+- 原始字节优先完整备份；
+- 是否生成 JPEG Preview 属于 Photo Derived Asset；
+- Live Photo 未来可将 image + video 作为 Companion Asset；
+- RAW + JPEG 可投影为同一个 Photo 的多个 Original Role，但 Drive 中仍可保留明确文件节点。
+
+### 21.6 Metadata
+
+上传阶段可以提交：
+
+- capture time hint；
+- local asset id；
+- media type；
+- dimensions；
+- location hint（若用户授权）；
+- album / source collection hint。
+
+这些只是候选来源，最终 EXIF / GPS / Capture Time 由 Photo 子系统解析和裁决。
+
+### 21.7 后台限制
+
+移动系统可能限制后台执行，因此客户端必须支持：
+
+- foreground acceleration；
+- background best effort；
+- pending queue；
+- Wi-Fi only；
+- charging only（可选）；
+- mobile data size threshold；
+- low battery pause；
+- retry with backoff。
+
+服务端不能假设手机客户端持续在线。
+
+### 21.8 用户删除本地照片
+
+备份完成后用户可以选择本地释放空间。
+
+Ikaros 必须能明确区分：
+
+- local deleted；
+- remote backup retained；
+- remote photo available；
+- local original cached / downloaded。
+
+不能把“本地不存在”显示成“备份丢失”。
+
+---
+
+## 22. 通用目录同步
+
+目录同步支持用户选择：
+
+- Desktop folder；
+- NAS mounted folder（客户端可访问时）；
+- Android SAF folder；
+- 其他客户端可持久访问的目录。
+
+### 22.1 Include / Exclude
+
+至少支持：
+
+- glob；
+- file extension；
+- hidden files；
+- max size；
+- temporary file pattern；
+- `.git` / build output 等默认建议忽略项。
+
+过滤规则必须版本化并可解释。
+
+### 22.2 Symlink
+
+默认不跟随 symlink 逃逸 Sync Root。
+
+可选策略必须明确：
+
+- ignore link；
+- sync link metadata（未来）；
+- follow target only if target remains inside root。
+
+### 22.3 Sparse / Placeholder
+
+桌面端未来可以支持按需文件：
+
+- 本地仅保留 Placeholder；
+- 打开时下载；
+- 用户可 Pin Offline。
+
+但这属于客户端文件系统集成增强能力，P0 不要求虚拟文件系统驱动。
+
+---
+
+## 23. Sync State
+
+Binding 状态建议：
+
+- IDLE；
+- SCANNING；
+- SYNCING；
+- PAUSED；
+- DEGRADED；
+- ERROR；
+- AUTH_REQUIRED；
+- FULL_RESYNC_REQUIRED；
+- DISABLED。
+
+单项状态建议：
+
+- IN_SYNC；
+- LOCAL_ONLY；
+- REMOTE_ONLY；
+- UPLOADING；
+- DOWNLOADING；
+- PENDING_DELETE；
+- CONFLICT；
+- ERROR；
+- IGNORED。
+
+`SYNCING` 不是 Background Task 的全局任务状态替代。大型 Full Scan / Initial Backup 可以关联 Background Task。
+
+---
+
+## 24. Full Resync
+
+以下情况必须允许 Full Resync：
+
+- Tombstone Retention 已过期；
+- Cursor 无效；
+- 客户端 Mapping DB 损坏；
+- 用户更改关键 Sync Policy；
+- 服务端检测映射不一致；
+- 客户端重装后用户选择重新关联原 Binding。
+
+Full Resync 必须是“重建映射”，不是“重新上传所有字节”。
+
+应优先利用：
+
+- Remote Node ID；
+- local stable id；
+- hash；
+- file size；
+- relative path；
+- revision metadata。
+
+来避免重复上传。
+
+---
+
+## 25. 配额与空间统计
+
+Drive 对用户展示的是逻辑空间，不直接等同于 Storage Physical Size。
+
+至少区分：
+
+- Logical Current File Size；
+- Revision Retained Size；
+- Trash Retained Size；
+- Physical Unique Blob Size（管理员统计）；
+- Replica Physical Size（管理员统计）；
+- Cache Size（不计入 Drive 逻辑配额，除非另有策略）。
+
+### 25.1 去重与配额
+
+P0 推荐用户配额按逻辑引用大小计费，而不是按物理去重后的 Blob 大小计费。
+
+原因：
+
+- 规则稳定；
+- 不泄露其他用户是否已有同一 Blob；
+- 用户行为可预测；
+- 多用户共享 Blob 不产生复杂公平分摊。
+
+实例管理员仍可在 Analytics 查看物理去重节省量。
+
+---
+
+## 26. 权限与安全
+
+### 26.1 默认权限
+
+Personal Drive 默认仅 Owner 可见。
+
+用户显式 Share 后授予目标用户 / Token 对特定 Node Scope 的权限。
+
+### 26.2 Folder ACL
+
+Folder Share 可以产生继承 Scope，但最终 ACL 语义由 Security / Sharing 设计决定。
+
+Drive 不自行实现第二套权限系统。
+
+### 26.3 本地路径隐私
+
+本地绝对路径可能包含：
+
+- 用户真实姓名；
+- 公司项目名；
+- 隐私目录名。
+
+因此：
+
+- 普通 Event / Analytics 不记录完整绝对路径；
+- 服务端最多保存受保护 Display Path，用于用户自己诊断；
+- 日志默认只记录 Binding ID / Relative Path Hash 或必要片段。
+
+### 26.4 Hash 隐私
+
+Hash Dedup API 不得成为跨用户内容存在性探测接口。
+
+### 26.5 恶意文件
+
+Drive 允许保存任意用户文件，不应因为无法识别格式就拒绝。
+
+但系统应为未来扩展保留：
+
+- malware scanning artifact；
+- suspicious file warning；
+- executable download warning；
+- archive bomb protection；
+- preview sandbox。
+
+这些安全检查不能无提示破坏原文件。
+
+---
+
+## 27. 专业领域投影
+
+Drive File 可以触发可选领域投影：
+
+```text
+Drive File Revision
+      ↓
+Attachment
+      ↓
+Domain Classifier / User Intent
+      ├── Photo Resource
+      ├── Media Resource
+      ├── Document Resource
+      ├── Music Resource
+      └── Generic File only
+```
+
+### 27.1 Generic File First
+
+未知文件先作为 Generic Drive File 存在，不要求所有文件必须转成 Core Resource。
+
+### 27.2 Auto Import Policy
+
+用户或 Instance 可配置：
+
+- 图片自动进入 Photos；
+- 视频仅 Camera Roll 自动进入 Photos / Media；
+- PDF / Office 不自动创建 Document；
+- 特定 Folder 作为 Ingestion Source；
+- 完全关闭自动领域投影。
+
+### 27.3 删除边界
+
+如果 Drive File 已被专业 Resource 引用，删除 Drive Node 不应绕过目标领域规则直接删除 Resource。
+
+需要明确 Attachment 引用生命周期和“从 Drive 移除”与“删除内容资源”的不同语义。
+
+---
+
+## 28. Search / Recent / Favorites
+
+Drive Search 至少支持：
+
+- filename；
+- extension / media type；
+- folder scope；
+- created / modified；
+- size；
+- owner / shared；
+- content-derived metadata（若对应领域提供）。
+
+`Recent` 是 Activity / Access Projection，不是特殊目录。
+
+`Favorites` 可复用 Core User State 或 Drive 专用 Pin 语义，但需要保持跨端同步。
+
+全文内容搜索由 Search / Document / OCR 等能力提供，不在 Drive 内自己实现第二套索引。
+
+---
+
+## 29. API / Command 语义
+
+最终路径由 API Convention 决定，本文仅定义能力。
+
+### 29.1 Query
+
+至少需要：
+
+- Get Drive Space；
+- List Folder Children；
+- Get Node Metadata；
+- Resolve Breadcrumb / Ancestors；
+- List Revisions；
+- Search Drive；
+- List Trash；
+- List Sync Bindings；
+- Get Sync Status；
+- List Conflicts；
+- Get Upload Session；
+- Get Quota Usage。
+
+### 29.2 Command
+
+至少需要：
+
+- Create Folder；
+- Begin Upload；
+- Finalize Upload；
+- Replace File；
+- Rename Node；
+- Move Node；
+- Copy Node；
+- Trash Node；
+- Restore Node；
+- Request Permanent Delete；
+- Restore Revision；
+- Create Sync Binding；
+- Update Sync Policy；
+- Pause / Resume Sync Binding；
+- Submit Sync Mutation Batch；
+- Resolve Conflict；
+- Request Full Resync；
+- Start Initial Backup / Scan。
+
+### 29.3 Idempotency
+
+以下操作必须支持稳定 Idempotency Key / Operation ID：
+
+- Finalize Upload；
+- Create Revision；
+- Sync Mutation；
+- Folder Copy；
+- Initial Backup batch；
+- Conflict Copy creation。
+
+---
+
+## 30. Event
+
+建议公开领域 Event：
+
+- `drive.node.created`；
+- `drive.node.renamed`；
+- `drive.node.moved`；
+- `drive.file.revision.created`；
+- `drive.node.trashed`；
+- `drive.node.restored`；
+- `drive.node.purged`；
+- `drive.sync.binding.created`；
+- `drive.sync.binding.state_changed`；
+- `drive.sync.conflict.detected`；
+- `drive.sync.conflict.resolved`；
+- `drive.photo_backup.completed`；
+- `drive.photo_projection.failed`；
+- `drive.quota.threshold_reached`。
+
+Event 只携带必要业务事实，不包含：
+
+- Storage Object Key；
+- Secret；
+- 本地绝对路径；
+- 未授权 GPS；
+- 大块文件内容。
+
+所有 Event 使用 Event Contract Version。
+
+---
+
+## 31. 数据库概念模型
+
+Drive 子系统建议拥有：
+
+```text
+drive_space
+
+drive_node
+  ├── file / folder common fields
+  └── parent-child hierarchy
+
+drive_file_revision
+
+drive_special_folder
+
+drive_trash_metadata  # 可合并进 node lifecycle metadata
+
+drive_sync_binding
+
+drive_sync_item_mapping
+
+drive_sync_conflict
+
+drive_sync_tombstone / change projection
+
+drive_quota_projection
+```
+
+### 31.1 Schema Ownership
+
+Drive 表由 Drive Migration 拥有。
+
+Storage、Photo、Offline Sync 等子系统不得直接更新 Drive 私有表。
+
+### 31.2 外键策略
+
+领域内部强一致引用可以使用外键，例如：
+
+- revision -> file node；
+- node -> drive space；
+- node -> parent node。
+
+跨领域引用例如 Attachment ID、Device ID、User ID 是否使用物理 FK，应遵守 Database Overview 的边界和部署策略，不通过跨领域 JOIN 修改对方状态。
+
+### 31.3 层级查询
+
+Folder Tree 可以使用：
+
+- adjacency list（`parent_id`）作为事实模型；
+- recursive CTE 查询祖先 / 后代；
+- 可选 materialized path / closure projection 作为性能优化。
+
+不能把缓存 Path Projection 变成唯一真相。
+
+---
+
+## 32. 一致性与事务边界
+
+### 32.1 创建 Revision
+
+需要保证：
+
+- Attachment 已成功创建；
+- Revision 唯一；
+- File current revision CAS 成功；
+- Outbox Event 与领域提交同事务。
+
+若 CAS 失败，产生 Conflict，不覆盖别人刚提交的 Revision。
+
+### 32.2 Move / Rename
+
+同一 Drive Schema 内可以 ACID 保证：
+
+- parent 存在；
+- 不形成目录循环；
+- 目标名称不冲突；
+- node version 更新。
+
+### 32.3 跨领域 Photo Projection
+
+Drive Upload 成功与 Photo Resource 创建采用最终一致性：
+
+```text
+Drive Revision committed
+      ↓ outbox
+Photo Projection Consumer
+      ↓
+Photo Resource / Asset
+```
+
+Photo Projection 失败不回滚原始备份。
+
+---
+
+## 33. 目录循环与树约束
+
+Move Folder 时必须防止：
+
+```text
+A
+└── B
+    └── C
+
+Move A into C  # invalid
+```
+
+实现可以使用 recursive CTE / ancestry projection 检查。
+
+并发 Move 必须结合 Node Version / Lock 防止竞态形成循环。
+
+---
+
+## 34. Background Task
+
+以下操作建议进入 Background Task：
+
+- 大目录 Copy；
+- 大目录 Trash / Restore；
+- Initial Sync Scan；
+- Full Resync；
+- 历史照片首次备份；
+- 大批量 Revision Retention Cleanup；
+- Drive Integrity Reconcile；
+- Domain Projection Rebuild。
+
+任务状态继续使用系统级：
+
+`Pending / Running / Succeeded / Failed / Cancelled / TimedOut`。
+
+Drive 可以有业务阶段，例如 `Scanning / Uploading / Applying Remote Changes`，但不能替代系统 Task State。
+
+---
+
+## 35. 可观测性
+
+需要至少统计：
+
+- active drive users；
+- node count；
+- current logical bytes；
+- revision retained bytes；
+- trash bytes；
+- upload throughput；
+- dedup hit ratio（管理员）；
+- sync bindings by mode；
+- backup pending count；
+- conflict count；
+- failed item count；
+- full resync count；
+- mobile backup success rate；
+- average sync lag；
+- Photo projection lag / failure。
+
+日志 / Trace 使用：
+
+- request id；
+- task id；
+- binding id；
+- operation id；
+- node id；
+- attachment id；
+
+而不是记录完整本地路径和 Secret。
+
+---
+
+## 36. 故障恢复
+
+### 36.1 Upload Interrupted
+
+Upload Session 保留已完成 Part，客户端恢复后续传。
+
+过期 Session 后由 Reaper 清理临时对象。
+
+### 36.2 Finalize 重复请求
+
+通过 Idempotency Key 返回同一结果，不重复创建 Revision。
+
+### 36.3 Client Crash During Apply
+
+客户端必须先落本地事务 / Journal，再推进 Cursor。
+
+### 36.4 Server Crash During Sync Batch
+
+每项 Operation 独立幂等；已提交项不会因整个 Batch 重试而重复执行。
+
+### 36.5 Storage Temporary Failure
+
+Drive Node / Revision 元数据不能因为短暂 Provider 故障消失。
+
+文件显示为 Remote / Unavailable / Restoring 等专业可用性状态。
+
+---
+
+## 37. P0 / P1 / Future
+
+### 37.1 P0
+
+- Personal Drive Space；
+- File / Folder Tree；
+- Upload / Download / Range；
+- resumable upload；
+- Rename / Move / Copy；
+- Trash / Restore；
+- immutable File Revision；
+- Revision Restore；
+- Desktop / Mobile directory BACKUP；
+- TWO_WAY directory sync；
+- Sync Binding / Mapping / Cursor；
+- Conflict Copy；
+- Camera Roll automatic backup；
+- Wi-Fi / mobile data policy；
+- Photo projection；
+- Share integration；
+- logical quota；
+- Background Task / audit / events。
+
+### 37.2 P1
+
+- selective sync；
+- placeholder / online-only file；
+- pinned offline folder；
+- richer revision retention UI；
+- duplicate management UI；
+- remote folder rule / automatic organization；
+- richer mobile album selection；
+- storage optimization after verified backup；
+- integrity reconcile dashboard；
+- malware scanning plugin integration。
+
+### 37.3 Future
+
+- virtual filesystem driver；
+- WebDAV endpoint；
+- LAN accelerated transfer；
+- peer-assisted transfer；
+- Trusted Edge Storage；
+- collaborative shared drive；
+- end-to-end encrypted drive scope；
+- filesystem snapshot integration；
+- block-level delta upload for very large mutable files；
+- content-defined chunking；
+- cross-instance replication / federation。
+
+---
+
+## 38. 不采用的设计
+
+### 38.1 不把 Storage Provider 当作网盘目录
+
+错误：
+
+```text
+Drive Folder = /mnt/data/user1
+```
+
+问题：
+
+- 无法迁移 Provider；
+- 无法多副本；
+- 路径泄露基础设施；
+- 无法稳定分享和版本化。
+
+### 38.2 不把 Blob 当作文件
+
+Blob 只有不可变字节身份，没有：
+
+- filename；
+- parent folder；
+- trash；
+- user revision history；
+- sync mapping。
+
+### 38.3 不使用 Last Modified Time 做双向冲突决策
+
+客户端时间可能：
+
+- 不同步；
+- 被用户修改；
+- 文件拷贝时保留旧时间；
+- 不同文件系统精度不同。
+
+必须使用 Revision / Base Version。
+
+### 38.4 不让 Camera Backup 直接等于 Photo Resource 上传 API
+
+否则会失去：
+
+- 通用文件备份；
+- 目录组织；
+- 原始字节统一 Revision；
+- Drive 与 Photo 的清晰边界。
+
+### 38.5 不默认传播本地删除
+
+尤其 Camera Backup 场景，备份的意义就是本地可以释放空间而不丢远端内容。
+
+---
+
+## 39. 关键用户流程
+
+### 39.1 Web 上传文件
+
+```text
+用户进入 My Drive
+  ↓
+选择文件
+  ↓
+Begin Upload Session
+  ↓
+上传 / 续传
+  ↓
+Finalize
+  ↓
+创建 File Node + Revision
+  ↓
+可选专业领域投影
+  ↓
+列表出现文件
+```
+
+### 39.2 手机首次备份照片
+
+```text
+用户授权 Photos / MediaStore
+  ↓
+创建 Camera Roll Backup Binding
+  ↓
+选择：全部历史 / 最近 N 天 / 从现在开始
+  ↓
+增量枚举本地资产
+  ↓
+过滤已备份 Mapping
+  ↓
+后台 resumable upload
+  ↓
+Drive Revision committed
+  ↓
+Photo Projection
+  ↓
+Photos Timeline 可见
+```
+
+### 39.3 两台电脑同步同一目录
+
+```text
+PC-A edit report.docx from rev 5
+PC-B edit report.docx from rev 5
+
+PC-A uploads -> rev 6
+PC-B later uploads with base rev 5
+          ↓
+Conflict detected
+          ↓
+keep report.docx = rev 6
+create report (conflict from PC-B).docx
+          ↓
+user manually resolves
+```
+
+### 39.4 本地删除已备份照片
+
+```text
+Phone local photo deleted
+  ↓
+Binding mode = BACKUP / KEEP_REMOTE
+  ↓
+mapping records local missing
+  ↓
+Remote Drive File remains
+  ↓
+Photo Timeline remains available
+```
+
+---
+
+## 40. 设计结论
+
+Ikaros V2 的网盘子系统应被定位为：
+
+> **建立在 Attachment / Blob / Storage 之上的用户文件空间，并通过 Device Sync Runtime 提供可靠的目录与手机媒体同步，再通过领域投影把文件接入 Photos、Media、Document 等专业内容体验。**
+
+最终核心分层为：
+
+```text
+User-visible File Space
+Drive Space / Folder / File
+          ↓
+Immutable File Revision
+          ↓
+Attachment / Blob
+          ↓
+Storage Provider / Replica
+```
+
+同步分层为：
+
+```text
+Local Directory / Camera Roll
+          ↓
+Sync Binding + Mapping
+          ↓
+Drive Command / Revision Conflict Rules
+          ↓
+Offline Sync Runtime / Cursor / Mutation
+          ↓
+Remote Drive Tree
+```
+
+照片备份分层为：
+
+```text
+Camera Roll
+   ↓ Backup
+Drive File + Original Attachment
+   ↓ Projection
+Photo Resource / Timeline / Album / EXIF
+```
+
+这样既能实现传统“个人网盘”的通用文件体验，也能实现类似 Immich 的手机照片自动备份，并为桌面目录双向同步、跨设备一致性、版本历史、回收站、分享和未来虚拟文件系统留下稳定演进空间。


### PR DESCRIPTION
## 概述

新增 Ikaros V2 的 Personal Drive / File Synchronization 子系统设计：

- `docs/v2/Personal-Drive-File-Synchronization-Subsystem-Design.md`
- `docs/v2/Personal-Drive-File-Synchronization-P0-Semantics.md`

本设计用于补齐 V2 的个人网盘与设备文件同步能力，目标同时覆盖：

- 传统个人网盘文件 / 文件夹体验；
- 桌面与移动端目录同步；
- 类似 Immich 的手机照片 / 视频自动备份；
- 文件版本、回收站、分享、配额与跨设备冲突处理。

## 核心设计

### 1. 网盘文件树

引入 Drive Space、Drive Node、File / Folder Tree、File Revision、Trash、Special Folder。

明确：

- Drive Node ID ≠ Path
- File Revision 不可变
- Move / Rename 不改变 File Identity
- Copy 可以复用 Blob，但创建新的业务 Node

### 2. 文件版本与 Blob 边界

```text
Drive File Node
      ↓ current revision
File Revision
      ↓
Attachment
      ↓
Blob
      ↓
Placement / Storage Provider
```

Drive 不保存 Provider Object Key / Bucket / 绝对物理路径作为文件身份。覆盖文件时创建新的 File Revision，不修改旧 Blob。

### 3. 目录同步

支持：

- BACKUP
- UPLOAD_ONLY
- DOWNLOAD_ONLY
- TWO_WAY

Sync Cursor / Pending Mutation 等可靠传输能力继续复用 `Offline-Cache-Device-Synchronization-Subsystem-Design.md`，Drive 只负责文件领域语义与冲突规则。

### 4. P0 Change Feed / Generation

补充 Drive 专用 Change Sequence，明确区分：

- NODE_CREATED
- CONTENT_REVISION_CREATED
- NODE_RENAMED
- NODE_MOVED
- NODE_TRASHED
- NODE_RESTORED
- NODE_PURGED

Rename / Move 不解释成 Delete + Create；Cursor 只有在变化已安全应用、持久忽略或进入可恢复 Conflict 后才能推进。

### 5. Trash / Restore / Tombstone

Restore 保持同一 Node ID，通过更高 `node_version + change sequence` 覆盖旧 Tombstone。

例如：

```text
node 123
v5 ACTIVE
   ↓ seq 20
v6 TRASHED
   ↓ seq 21
v7 ACTIVE
```

旧 Tombstone 不得再次删除已恢复 Node；Purge 完成后同一 Node Identity 不允许复活。

### 6. 文件时间语义

明确区分：

- Drive `created_at`
- Drive `updated_at`
- `content_modified_at`
- `source_created_at`
- `source_modified_at`

上传时间不会覆盖源文件修改时间；mtime + size 只用于快速变化检测，不参与最终内容身份和冲突裁决。

### 7. Atomic Save / Change Coalescing

OS Watcher 事件只作为 Dirty Hint，不直接映射成远端 Mutation。

针对 Office、VS Code、JetBrains 等常见临时文件替换保存：

```text
Watcher Events
    ↓
Change Coalescing / Settle
    ↓
Re-stat / Mapping / Fingerprint
    ↓
Logical Local Delta
```

避免一次正常保存被错误解释为 Trash + Create + Conflict。

### 8. Quota Reservation

Begin Upload 需要先预留逻辑配额：

```text
Begin Upload
  ↓ reserve quota
Upload Session
  ↓
Finalize
  ↓
Commit actual usage
  ↓
Release reservation
```

Abort / Expire 必须释放 Reservation；Dedup 命中不降低用户逻辑配额预留。

### 9. 手机照片 / 视频自动备份

Camera Backup 默认：

- `source_kind = CAMERA_ROLL`
- `mode = BACKUP`
- `delete_policy = KEEP_REMOTE`
- `conflict_policy = PRESERVE_BOTH`

本地删除照片默认不删除 Ikaros 已备份内容。

同时保持：

- Drive 拥有文件备份位置与同步状态；
- Photo 子系统拥有 EXIF、Capture Time、GPS、Album、Preview / Thumbnail 等专业图片语义。

### 10. Backup Verified / Free Up Space

HTTP Upload 成功不等于可以安全删除手机原件。

只有完成：

```text
Upload Complete
  ↓
Blob Verified
  ↓
Storage Policy Minimum Placement Available
  ↓
Attachment Persisted
  ↓
Drive Revision Committed
  ↓
Camera Mapping Persisted
  ↓
BACKUP_VERIFIED
```

才允许客户端提供 `Free Up Space`。

Photo Projection 失败不影响 Original 已安全备份状态，因为 Projection 可重建，而 Original 丢失不可接受。

### 11. Camera Source Availability

明确：`Asset Discovered ≠ Original Readable`。

支持：

- WAITING_FOR_LOCAL_ORIGINAL
- PERMISSION_REQUIRED
- SOURCE_UNAVAILABLE
- BACKUP_VERIFIED

用于处理 iCloud Photos 优化存储、Android cloud-only media、Limited Photos Permission、App 重装等实际移动端场景。

### 12. Sync Binding 重叠与回环

P0 默认禁止同一设备上的可写 Binding 出现：

- 本地 Scope 祖先 / 后代重叠；
- Remote Root 祖先 / 后代重叠；
- 一个 Binding 的 Download 输出成为另一个 Upload Binding 输入。

避免重复上传和同步回环。

### 13. Copy Revision 语义

普通 File Copy：

```text
Source current rev 8
      ↓ Copy
New File Node
revision 1 -> same Attachment / Blob
```

不复制完整 Revision History；完整历史克隆未来作为独立能力。

### 14. 跨平台文件系统边界

P0 明确处理 Unicode normalization、case collision、Windows reserved names、trailing dot / space、case-only rename、路径长度等。

同时明确 P0 不是完整 POSIX filesystem clone，不承诺完整同步 uid/gid、ACL、xattr、resource fork、ADS、device file 等元数据。

### 15. Shared Folder 同步限制

P0 默认只允许拥有写控制权的 Personal Drive Folder 作为 TWO_WAY Sync Root。

Shared Folder 可选支持 DOWNLOAD_ONLY；Shared TWO_WAY 延后到 P1，避免把权限撤销和同步冲突状态机在 P0 过早耦合。

## 与现有设计的边界

本设计主动与以下 V2 文档保持一致：

- `System-Overview-Design.md`
- `Database-Overview-Design.md`
- `API-Convention-Design.md`
- `Attachment-Blob-Storage-Subsystem-Design.md`
- `Offline-Cache-Device-Synchronization-Subsystem-Design.md`
- `Content-Ingestion-Metadata-Synchronization-Subsystem-Design.md`
- `Photo-Album-Image-Asset-Subsystem-Design.md`
- `Sharing-Collaboration-Room-Subsystem-Design.md`
- `Background-Task-Scheduler-Design.md`

## P0 验收重点

补充设计给出了 18 个 Integration / E2E 不变量，覆盖：

- Rename / Move 不重复上传；
- Trash + Restore 不被旧 Tombstone 再删；
- Purged Node 不复活；
- 双端修改保留 Conflict Copy；
- Atomic Save 只产生有效 Revision；
- Quota Reservation 防止并发超额；
- Camera Backup 必须验证后才能释放本地原件；
- Photo Projection 失败不影响 Original Backup；
- cloud-only asset 正确等待；
- App 重装后映射重建；
- Binding 重叠阻止回环；
- Copy 不复制完整历史；
- case-only rename；
- Shared Folder P0 权限边界；
- Cursor 过期明确要求 Full Resync；
- Operation ID 重试不产生重复副作用。

## 变更范围

本 PR 仅新增两个 Drive 专项设计文档，未修改共享 README / System Overview，以降低与并行 V2 文档工作的合并冲突风险。

当前分支相对 `main`：

- ahead 2 commits
- behind 0
- 2 new files
- 2,772 additions
