### PR TITLE
docs(v2): converge P0 engineering contracts

### DIFF
--- a/docs/v2/P0-API-Contract-Coverage-Map.md
+++ b/docs/v2/P0-API-Contract-Coverage-Map.md
@@ -1,26 +1,86 @@
 # Ikaros V2 P0 API / Contract Coverage Map
 
-> This small registry exists to make the P0 contract set discoverable and machine-review friendly.
+| 项目 | 内容 |
+|---|---|
+| Baseline | `v2-p0-foundation-0.2` |
+| Base OpenAPI | `api/openapi-v2-p0.yaml` |
+| Convergence Addendum | `api/openapi-v2-p0-contract-convergence.yaml` |
+| Machine Registry | `contracts/P0-HTTP-Operation-Registry.yaml` |
+| Event Schema | `contracts/schema/p0-event-v1.schema.json` |
 
-## Contract files
+> Application Contract exists ≠ public HTTP endpoint exists. Controller-first changes are prohibited.
 
-- `contracts/P0-Command-Query-Event-Catalog.md` — application command/query/event registry, permissions, idempotency, producer/consumer mapping and HTTP operation mapping.
-- `contracts/P0-Event-Payload-Schema-Registry.md` — payload shapes and compatibility rules for initial P0 events.
-- `api/openapi-v2-p0.yaml` — machine-readable OpenAPI 3.1 baseline.
+## Contract Files
 
-## P0 contract rule
+- `P0-Implementation-Baseline.md` — Phase 0 engineering GO / frozen boundary.
+- `P0-Requirement-Traceability-Matrix.md` — Requirement → Contract → DB → API → Event → Test traceability.
+- `contracts/P0-Command-Query-Event-Catalog.md` — Application Command / Query / Event authority.
+- `contracts/P0-Event-Payload-Schema-Registry.md` — human-readable event payload compatibility contract.
+- `contracts/schema/p0-event-v1.schema.json` — machine-readable Event Envelope / Type / Version baseline.
+- `contracts/P0-HTTP-Operation-Registry.yaml` — complete public P0 HTTP operation mapping.
+- `api/openapi-v2-p0.yaml` — original P0 OpenAPI baseline.
+- `api/openapi-v2-p0-contract-convergence.yaml` — additive coverage for Catalog-declared HTTP operations missing from the original spec.
+- `testing/P0-Acceptance-Invariant-Test-Matrix.md` — REQUIRED engineering gates.
 
-A new public P0 endpoint is not complete until all applicable layers exist:
+## P0 Public API Rule
 
 ```text
 Subsystem capability
   -> Command or Query ID
-  -> Permission key
-  -> HTTP operationId (when public HTTP exists)
+  -> Permission / authorization policy
+  -> HTTP operationId
+  -> HTTP Operation Registry
   -> OpenAPI request/response schema
-  -> Event type/version (when a durable fact is produced)
-  -> Producer/consumer mapping
+  -> Event type/version (when durable fact exists)
   -> Acceptance/invariant test
 ```
 
-Controller-first changes are prohibited.
+CI should verify operationId uniqueness, method/path uniqueness, Registry → OpenAPI existence, Registry contract IDs → Catalog existence, and OpenAPI reference validity.
+
+## Coverage After Convergence
+
+The original OpenAPI baseline has **16** public operations. The convergence addendum adds **12** missing mappings, for **28** public P0 operations total.
+
+Newly covered contracts:
+
+- `resource.find-by-external-identity`
+- `resource.trash-resource`
+- `resource.get-user-state`
+- `resource.list-tags`
+- `resource.list-collections`
+- `operations.list-background-tasks`
+- `operations.list-task-attempts`
+- `storage.list-blob-placements`
+- `storage.get-provider`
+- `identity.get-current-user`
+- `identity.list-sessions`
+- `identity.get-user`
+
+The exact machine list is `contracts/P0-HTTP-Operation-Registry.yaml`.
+
+## Intentionally Not Public Yet
+
+The following Application Contracts remain internal or `contract-deferred` until route/request/response, authorization/step-up, idempotency and concurrency semantics are frozen:
+
+- Resource mutation contracts for external identities, tags, collections and user-state;
+- Storage attachment lifecycle, blob verify/GC, provider update/enable/disable/drain;
+- `operations.retry-background-task`;
+- Identity user/role/session mutation commands not already in the base OpenAPI.
+
+Do not invent Controller routes for these capabilities.
+
+## Event Machine Contract
+
+`contracts/schema/p0-event-v1.schema.json` locks the P0 event envelope, UUIDv7 event ID, schema version, producer namespace and the current **43 P0 v1 Event Types**. Per-event payload field constraints remain governed by `P0-Event-Payload-Schema-Registry.md` and must be expanded into machine compatibility checks during Phase 0 implementation (`P0-EVT-004/013/014`).
+
+## Change Checklist
+
+- [ ] Catalog Command / Query exists.
+- [ ] Permission / object authorization is explicit.
+- [ ] OpenAPI operationId exists.
+- [ ] HTTP Operation Registry entry exists.
+- [ ] New/changed operation carries `x-ikaros-contract-id`.
+- [ ] Idempotency / concurrency semantics are explicit.
+- [ ] Event schema / payload registry is synchronized when applicable.
+- [ ] Acceptance Test ID exists.
+- [ ] Traceability Matrix is synchronized.

--- a/docs/v2/P0-Implementation-Baseline.md
+++ b/docs/v2/P0-Implementation-Baseline.md
@@ -1,0 +1,104 @@
+# Ikaros V2 P0 Engineering Foundation Contract Baseline
+
+| 项目 | 内容 |
+|---|---|
+| Baseline ID | `v2-p0-foundation-0.2` |
+| Baseline Date | 2026-09-02 |
+| 状态 | **Accepted for Phase 0 Engineering Foundation** |
+| 目标 | 允许 V2 从设计阶段进入 Phase 0 Engineering Foundation 实现 |
+| 非目标 | 不宣称 Phase 1+ 所有业务域已经冻结 |
+
+> 本 Baseline 是“进入下一阶段”的工程 Gate 决议。它冻结 Phase 0 所需的基础契约，不把整个 V2 宣布为 Final。
+
+## 1. Decision
+
+```text
+Phase 0 — Engineering Foundation = GO
+Phase 1+ Domain Implementation = gated per module Definition of Ready
+Release Readiness = NOT YET
+```
+
+下一阶段默认产出应转向 module skeleton、Flyway、Application API、Outbox/Inbox、Background Task runtime 与自动化测试，而不是继续横向增加 P0 设计文档。
+
+## 2. Normative Baseline Set
+
+Phase 0 实现至少以以下文档为输入：
+
+- `Product-Requirements-Document.md`
+- `System-Overview-Design.md`
+- `Database-Overview-Design.md`
+- `API-Convention-Design.md`
+- `Implementation-Roadmap-and-Dependency-Graph.md`
+- `Module-Package-Ownership-Design.md`
+- `Plugin-Runtime-SDK-Lifecycle-Design.md`
+- `database/P0-Database-Schema-Design.md`
+- `contracts/P0-Command-Query-Event-Catalog.md`
+- `contracts/P0-Event-Payload-Schema-Registry.md`
+- `contracts/schema/p0-event-v1.schema.json`
+- `api/openapi-v2-p0.yaml`
+- `api/openapi-v2-p0-contract-convergence.yaml`
+- `contracts/P0-HTTP-Operation-Registry.yaml`
+- `P0-Requirement-Traceability-Matrix.md`
+- `testing/P0-Acceptance-Invariant-Test-Matrix.md`
+
+Media Delivery / Restore 的独立 P0 Addendum 继续作为专项规范性扩展。
+
+## 3. Frozen Foundation Rules
+
+没有先修改设计/ADR 时，Phase 0 实现不得自行改变：
+
+- UUID public identity policy；
+- PostgreSQL owner schema boundary；
+- Resource / Attachment / Blob / Placement identity separation；
+- optimistic concurrency semantics；
+- Command / Query application boundary；
+- Outbox + Inbox atomicity / at-least-once / consumer idempotency；
+- Background Task / Attempt separation；
+- Permission Registry authority 与对象级授权边界；
+- Secret Reference boundary；
+- `/api/v2`、Problem、snake_case、Idempotency、ETag/If-Match、Range 等 API 规则；
+- Plugin private persistence boundary。
+
+## 4. Not Frozen Yet
+
+本 Baseline 不表示以下内容可以无条件并行编码：
+
+- Personal Drive full Schema / API / Event mapping；
+- Media / Reading / Music / Photo / Game / Document 全量专业领域 contract；
+- Productivity / Finance / Secure Domain 完整持久化与 public API；
+- V1 → V2 migration strategy；
+- production capacity / partition quantitative baseline；
+- 每个 Catalog Command 的 HTTP route。
+
+```text
+Application Contract exists != Public HTTP endpoint must exist
+```
+
+未进入 OpenAPI / HTTP Registry 的 Command 不允许由 Controller 自行猜测路由。
+
+## 5. Phase 0 Implementation Outputs
+
+建议按以下顺序推进：
+
+```text
+Module Skeleton
+ -> Architecture Boundary Tests
+ -> Flyway P0 Foundation Schema
+ -> UUIDv7 / Clock / Problem / Principal
+ -> Transaction + Outbox / Inbox
+ -> Background Task Runtime
+ -> Resource / Storage / Identity Application APIs
+ -> OpenAPI Controllers / DTOs
+ -> Contract / Recovery / Concurrency / Security Tests
+ -> P0 E2E Gates
+```
+
+## 6. Follow-up Gates
+
+Phase 1 Resource Core 对应能力实现前，至少补齐 Collection hierarchy、Resource Relation、必要的 Title/Alias mutation，以及当前 `contract-deferred` 的 public mutation surface。
+
+Personal Drive 和每个 Professional Domain 仍必须分别具备 Schema + Command/Query + Event + Permission + OpenAPI（适用时）+ Acceptance Matrix，才能进入其模块编码。
+
+## 7. Change Control
+
+实现发现契约问题时：先修改 Source of Truth / ADR 与测试契约，再改代码。禁止通过 Controller special-case、跨 Schema 私写、Repository hidden rule 或“先写代码后补契约”绕过 Gate。

--- a/docs/v2/P0-Requirement-Traceability-Matrix.md
+++ b/docs/v2/P0-Requirement-Traceability-Matrix.md
@@ -1,0 +1,64 @@
+# Ikaros V2 P0 Requirement / Contract Traceability Matrix
+
+| 项目 | 内容 |
+|---|---|
+| Baseline | `v2-p0-foundation-0.2` |
+| 状态 | Accepted / Engineering Traceability Baseline |
+| PRD | `Product-Requirements-Document.md` |
+| Catalog | `contracts/P0-Command-Query-Event-Catalog.md` |
+| Database | `database/P0-Database-Schema-Design.md` |
+| OpenAPI | `api/openapi-v2-p0.yaml` + `api/openapi-v2-p0-contract-convergence.yaml` |
+| HTTP Registry | `contracts/P0-HTTP-Operation-Registry.yaml` |
+| Acceptance | `testing/P0-Acceptance-Invariant-Test-Matrix.md` |
+
+> 本矩阵冻结 P0 Engineering Foundation / Core Platform 首批实现切片，不提前伪造 Phase 1+ 专业领域尚未冻结的 Schema/API。
+
+## 1. Traceability Rule
+
+```text
+PRD / System Requirement
+ -> Subsystem Invariant
+ -> Command / Query
+ -> Permission / Security Policy
+ -> DB Constraint / Transaction Boundary
+ -> HTTP operation（公开时）
+ -> Durable Event（产生事实时）
+ -> Acceptance Test ID
+```
+
+所有 public HTTP operation 必须进入 `contracts/P0-HTTP-Operation-Registry.yaml`。本轮新增 operation 还必须在 OpenAPI 中携带 `x-ikaros-contract-id`。
+
+## 2. P0 Traceability Slice
+
+| Requirement | Contract | DB / Transaction | Public HTTP | Event | Acceptance |
+|---|---|---|---|---|---|
+| `FR-LIB-01` Resource 浏览 | `resource.list-resources`, `resource.get-resource` | `resource.resource` | `listResources`, `getResource` | read-only | `P0-RES-001`, `P0-API-004`, `P0-SEC-004/005` |
+| `FR-LIB-03` Collection | create/add/remove/list collection contracts | `resource.collection`, `resource.collection_member` | `listCollections` | `resource.collection.*` | `P0-RES-021~024`, `P0-CON-004` |
+| `FR-LIB-05` 多标题 | create resource / title query | `resource.resource_title` | initial titles embedded in `createResource` | `resource.resource.created` | `P0-RES-011` |
+| `FR-LIB-06` External Identity | attach/detach/find | `resource.external_identity` unique key | `findResourceByExternalIdentity` | `resource.external-identity.*` | `P0-RES-016~018`, `P0-CON-002` |
+| Resource lifecycle | archive/restore/trash | resource version + outbox transaction | `archiveResource`, `restoreResource`, `trashResource` | lifecycle events | `P0-RES-003~010`, `P0-CON-001` |
+| User Resource State | set/get state | `resource.user_resource_state` | `getResourceUserState` | `resource.user-state.changed` | `P0-RES-027~029` |
+| `FR-STORAGE-01` Attachment / Blob 解耦 | attachment create/read/content | attachment + blob + placement | `getAttachment`, `getAttachmentContent` | `storage.attachment.*` | `P0-STO-001~007`, `P0-API-013` |
+| `FR-STORAGE-02` 多级对象存储 | provider/placement contracts | provider + placement | list/get providers, placements | `storage.provider.*` | `P0-STO-006/007/018/019` |
+| `FR-STORAGE-06` 内容完整性 | `storage.verify-blob` | blob integrity state | internal / async | verified / integrity-failed | `P0-STO-008~010`, `P0-REC-007` |
+| Blob GC safety | `storage.request-blob-gc` | reference recheck + background task | contract-deferred | gc-requested / purged | `P0-STO-011~015`, `P0-CON-007` |
+| Background Task | get/list/attempts/cancel/retry | Task + immutable Attempt history | get/list/attempts/cancel | `operations.background-task.*` | `P0-TASK-001~012`, recovery gates |
+| `FR-AUTH-01` Identity | current-user/session contracts | user + session digest/security_version | `getCurrentUser`, `listSessions` | identity/session events | `P0-ID-009~014` |
+| `FR-AUTH-02` Authorization | role/permission/user contracts | permission/role/binding tables | users/roles/permissions queries | role/user events | `P0-ID-004~008`, `P0-API-014` |
+| Durable Event | Event Envelope + producer/consumer matrix | outbox + inbox atomicity | N/A | 43 P0 v1 event types | `P0-EVT-001~014`, `P0-REC-001~005` |
+| `FR-PLUGIN-01/02` Plugin boundary | runtime/capability/permission contracts | plugin-owned persistence boundary | N/A | capability-mediated only | `P0-PLG-001~008`, `P0-SEC-008` |
+
+## 3. Known Pre-Phase-1 Expansion
+
+对应功能开工前必须补齐：
+
+- Collection hierarchy mutation；
+- Resource Relation mutation/query；
+- 独立 Title/Alias mutation（若首批 UI 需要）；
+- 当前 `contract-deferred` 的 public mutation surface。
+
+Personal Drive 与各 Professional Domain 仍必须分别满足 Roadmap Definition of Ready：Schema + Command/Query + Event + Permission + OpenAPI（公开时）+ Acceptance。
+
+## 4. Change Rule
+
+P0 语义变更必须同步所有适用层。暂不适用时明确写 `N/A` 或 `contract-deferred`，不得把空白解释为实现自由。

--- a/docs/v2/api/openapi-v2-p0-contract-convergence.yaml
+++ b/docs/v2/api/openapi-v2-p0-contract-convergence.yaml
@@ -1,0 +1,168 @@
+openapi: 3.1.0
+info:
+  title: Ikaros V2 P0 Contract Convergence API Addendum
+  version: 0.1.0
+  description: Additive HTTP contracts declared by the P0 Catalog but absent from the original P0 OpenAPI baseline.
+servers:
+  - url: /api/v2
+security:
+  - bearerAuth: []
+paths:
+  /resources:by-external-identity:
+    get:
+      operationId: findResourceByExternalIdentity
+      x-ikaros-contract-id: resource.find-by-external-identity
+      parameters:
+        - { name: provider, in: query, required: true, schema: { type: string } }
+        - { name: namespace, in: query, required: true, schema: { type: string } }
+        - { name: object_type, in: query, required: true, schema: { type: string } }
+        - { name: external_id, in: query, required: true, schema: { type: string } }
+      responses:
+        '200': { description: Matched resource, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/Resource' } } } }
+        '404': { $ref: './openapi-v2-p0.yaml#/components/responses/NotFound' }
+  /resources/{resource_id}/actions/trash:
+    parameters:
+      - { $ref: './openapi-v2-p0.yaml#/components/parameters/ResourceId' }
+    post:
+      operationId: trashResource
+      x-ikaros-contract-id: resource.trash-resource
+      parameters:
+        - { $ref: './openapi-v2-p0.yaml#/components/parameters/IfMatch' }
+      responses:
+        '200': { description: Trashed resource, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/Resource' } } } }
+        '412': { $ref: './openapi-v2-p0.yaml#/components/responses/PreconditionFailed' }
+        '428': { $ref: './openapi-v2-p0.yaml#/components/responses/PreconditionRequired' }
+  /resources/{resource_id}/user-state:
+    parameters:
+      - { $ref: './openapi-v2-p0.yaml#/components/parameters/ResourceId' }
+    get:
+      operationId: getResourceUserState
+      x-ikaros-contract-id: resource.get-user-state
+      responses:
+        '200': { description: Current user state, content: { application/json: { schema: { $ref: '#/components/schemas/UserResourceState' } } } }
+  /tags:
+    get:
+      operationId: listTags
+      x-ikaros-contract-id: resource.list-tags
+      parameters:
+        - { $ref: './openapi-v2-p0.yaml#/components/parameters/Cursor' }
+        - { $ref: './openapi-v2-p0.yaml#/components/parameters/Limit' }
+      responses:
+        '200': { description: Tag page, content: { application/json: { schema: { $ref: '#/components/schemas/Page' } } } }
+  /collections:
+    get:
+      operationId: listCollections
+      x-ikaros-contract-id: resource.list-collections
+      parameters:
+        - { $ref: './openapi-v2-p0.yaml#/components/parameters/Cursor' }
+        - { $ref: './openapi-v2-p0.yaml#/components/parameters/Limit' }
+      responses:
+        '200': { description: Collection page, content: { application/json: { schema: { $ref: '#/components/schemas/Page' } } } }
+  /background-tasks:
+    get:
+      operationId: listBackgroundTasks
+      x-ikaros-contract-id: operations.list-background-tasks
+      parameters:
+        - { $ref: './openapi-v2-p0.yaml#/components/parameters/Cursor' }
+        - { $ref: './openapi-v2-p0.yaml#/components/parameters/Limit' }
+        - { name: status, in: query, schema: { type: string } }
+        - { name: task_type, in: query, schema: { type: string } }
+      responses:
+        '200': { description: Background task page, content: { application/json: { schema: { $ref: '#/components/schemas/Page' } } } }
+  /background-tasks/{task_id}/attempts:
+    parameters:
+      - { $ref: './openapi-v2-p0.yaml#/components/parameters/TaskId' }
+    get:
+      operationId: listBackgroundTaskAttempts
+      x-ikaros-contract-id: operations.list-task-attempts
+      responses:
+        '200': { description: Attempt history, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/BackgroundTaskAttempt' } } } } }
+  /admin/blobs/{blob_id}/placements:
+    parameters:
+      - { name: blob_id, in: path, required: true, schema: { type: string, format: uuid } }
+    get:
+      operationId: listBlobPlacements
+      x-ikaros-contract-id: storage.list-blob-placements
+      responses:
+        '200': { description: Blob placements, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/BlobPlacement' } } } } }
+  /admin/storage-providers/{provider_id}:
+    parameters:
+      - { name: provider_id, in: path, required: true, schema: { type: string, format: uuid } }
+    get:
+      operationId: getStorageProvider
+      x-ikaros-contract-id: storage.get-provider
+      responses:
+        '200': { description: Storage provider, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/StorageProvider' } } } }
+  /me:
+    get:
+      operationId: getCurrentUser
+      x-ikaros-contract-id: identity.get-current-user
+      responses:
+        '200': { description: Current user, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/User' } } } }
+  /me/sessions:
+    get:
+      operationId: listSessions
+      x-ikaros-contract-id: identity.list-sessions
+      responses:
+        '200': { description: Sessions, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/SessionSummary' } } } } }
+  /admin/users/{user_id}:
+    parameters:
+      - { name: user_id, in: path, required: true, schema: { type: string, format: uuid } }
+    get:
+      operationId: getUser
+      x-ikaros-contract-id: identity.get-user
+      responses:
+        '200': { description: User, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/User' } } } }
+components:
+  securitySchemes:
+    bearerAuth: { type: http, scheme: bearer }
+  schemas:
+    Page:
+      type: object
+      required: [items]
+      properties:
+        items: { type: array, items: { type: object, additionalProperties: true } }
+        next_cursor: { type: [string, 'null'] }
+    UserResourceState:
+      type: object
+      required: [user_id, resource_id, favorite, version, updated_at]
+      properties:
+        user_id: { type: string, format: uuid }
+        resource_id: { type: string, format: uuid }
+        favorite: { type: boolean }
+        rating: { type: [number, 'null'], minimum: 0, maximum: 10 }
+        status_code: { type: [string, 'null'] }
+        progress_value: { type: [number, 'null'], minimum: 0 }
+        progress_unit: { type: [string, 'null'] }
+        version: { type: integer, minimum: 0 }
+        updated_at: { type: string, format: date-time }
+    BackgroundTaskAttempt:
+      type: object
+      required: [id, task_id, attempt_no, status, created_at]
+      properties:
+        id: { type: string, format: uuid }
+        task_id: { type: string, format: uuid }
+        attempt_no: { type: integer, minimum: 1 }
+        status: { type: string }
+        error_classification: { type: [string, 'null'] }
+        retryable: { type: [boolean, 'null'] }
+        created_at: { type: string, format: date-time }
+    BlobPlacement:
+      type: object
+      required: [id, blob_id, provider_id, state, tier]
+      properties:
+        id: { type: string, format: uuid }
+        blob_id: { type: string, format: uuid }
+        provider_id: { type: string, format: uuid }
+        state: { type: string }
+        tier: { type: string }
+    SessionSummary:
+      type: object
+      required: [id, user_id, security_version, svl, created_at, expires_at]
+      properties:
+        id: { type: string, format: uuid }
+        user_id: { type: string, format: uuid }
+        security_version: { type: integer, minimum: 0 }
+        svl: { type: integer, minimum: 0 }
+        created_at: { type: string, format: date-time }
+        expires_at: { type: string, format: date-time }

--- a/docs/v2/contracts/P0-HTTP-Operation-Registry.yaml
+++ b/docs/v2/contracts/P0-HTTP-Operation-Registry.yaml
@@ -1,0 +1,35 @@
+version: '0.2'
+baseline: v2-p0-foundation-0.2
+base_path: /api/v2
+sources:
+  - api/openapi-v2-p0.yaml
+  - api/openapi-v2-p0-contract-convergence.yaml
+operations:
+  - { method: POST, path: /resources, operation_id: createResource, contract_id: resource.create-resource, source: api/openapi-v2-p0.yaml }
+  - { method: GET, path: /resources, operation_id: listResources, contract_id: resource.list-resources, source: api/openapi-v2-p0.yaml }
+  - { method: GET, path: '/resources/{resource_id}', operation_id: getResource, contract_id: resource.get-resource, source: api/openapi-v2-p0.yaml }
+  - { method: PATCH, path: '/resources/{resource_id}', operation_id: updateResource, contract_id: resource.update-resource, source: api/openapi-v2-p0.yaml }
+  - { method: POST, path: '/resources/{resource_id}/actions/archive', operation_id: archiveResource, contract_id: resource.archive-resource, source: api/openapi-v2-p0.yaml }
+  - { method: POST, path: '/resources/{resource_id}/actions/restore', operation_id: restoreResource, contract_id: resource.restore-resource, source: api/openapi-v2-p0.yaml }
+  - { method: GET, path: '/attachments/{attachment_id}', operation_id: getAttachment, contract_id: storage.get-attachment, source: api/openapi-v2-p0.yaml }
+  - { method: GET, path: '/attachments/{attachment_id}/content', operation_id: getAttachmentContent, contract_id: storage.get-attachment-content, source: api/openapi-v2-p0.yaml }
+  - { method: GET, path: '/background-tasks/{task_id}', operation_id: getBackgroundTask, contract_id: operations.get-background-task, source: api/openapi-v2-p0.yaml }
+  - { method: POST, path: '/background-tasks/{task_id}/actions/cancel', operation_id: cancelBackgroundTask, contract_id: operations.cancel-background-task, source: api/openapi-v2-p0.yaml }
+  - { method: GET, path: /admin/storage-providers, operation_id: listStorageProviders, contract_id: storage.list-providers, source: api/openapi-v2-p0.yaml }
+  - { method: POST, path: /admin/storage-providers, operation_id: createStorageProvider, contract_id: storage.create-provider, source: api/openapi-v2-p0.yaml }
+  - { method: GET, path: /admin/users, operation_id: listUsers, contract_id: identity.list-users, source: api/openapi-v2-p0.yaml }
+  - { method: POST, path: /admin/users, operation_id: createUser, contract_id: identity.create-user, source: api/openapi-v2-p0.yaml }
+  - { method: GET, path: /admin/roles, operation_id: listRoles, contract_id: identity.list-roles, source: api/openapi-v2-p0.yaml }
+  - { method: GET, path: /admin/permissions, operation_id: listPermissions, contract_id: identity.list-permissions, source: api/openapi-v2-p0.yaml }
+  - { method: GET, path: '/resources:by-external-identity', operation_id: findResourceByExternalIdentity, contract_id: resource.find-by-external-identity, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: POST, path: '/resources/{resource_id}/actions/trash', operation_id: trashResource, contract_id: resource.trash-resource, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: GET, path: '/resources/{resource_id}/user-state', operation_id: getResourceUserState, contract_id: resource.get-user-state, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: GET, path: /tags, operation_id: listTags, contract_id: resource.list-tags, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: GET, path: /collections, operation_id: listCollections, contract_id: resource.list-collections, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: GET, path: /background-tasks, operation_id: listBackgroundTasks, contract_id: operations.list-background-tasks, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: GET, path: '/background-tasks/{task_id}/attempts', operation_id: listBackgroundTaskAttempts, contract_id: operations.list-task-attempts, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: GET, path: '/admin/blobs/{blob_id}/placements', operation_id: listBlobPlacements, contract_id: storage.list-blob-placements, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: GET, path: '/admin/storage-providers/{provider_id}', operation_id: getStorageProvider, contract_id: storage.get-provider, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: GET, path: /me, operation_id: getCurrentUser, contract_id: identity.get-current-user, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: GET, path: /me/sessions, operation_id: listSessions, contract_id: identity.list-sessions, source: api/openapi-v2-p0-contract-convergence.yaml }
+  - { method: GET, path: '/admin/users/{user_id}', operation_id: getUser, contract_id: identity.get-user, source: api/openapi-v2-p0-contract-convergence.yaml }

--- a/docs/v2/contracts/schema/p0-event-v1.schema.json
+++ b/docs/v2/contracts/schema/p0-event-v1.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ikaros.run/schemas/v2/p0-event-v1.schema.json",
+  "title": "Ikaros V2 P0 Durable Event v1",
+  "description": "Machine-readable P0 event envelope/type baseline. Payload field compatibility remains governed by P0-Event-Payload-Schema-Registry.md and is expanded into per-event schemas during Phase 0 implementation.",
+  "type": "object",
+  "required": ["event_id", "event_type", "schema_version", "occurred_at", "producer_subsystem", "payload"],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "resource.resource.created", "resource.resource.updated", "resource.resource.archived", "resource.resource.restored", "resource.resource.trashed",
+        "resource.external-identity.attached", "resource.external-identity.detached", "resource.tag.created", "resource.tag.added", "resource.tag.removed",
+        "resource.collection.created", "resource.collection.member-added", "resource.collection.member-removed", "resource.user-state.changed",
+        "storage.attachment.created", "storage.attachment.archived", "storage.attachment.trashed", "storage.blob.verified", "storage.blob.integrity-failed",
+        "storage.provider.created", "storage.provider.updated", "storage.provider.enabled", "storage.provider.disabled", "storage.provider.drain-requested",
+        "storage.blob.gc-requested", "storage.blob.purged",
+        "operations.background-task.created", "operations.background-task.started", "operations.background-task.succeeded", "operations.background-task.failed",
+        "operations.background-task.cancel-requested", "operations.background-task.cancelled", "operations.background-task.retry-requested", "operations.background-task.timed-out",
+        "identity.user.created", "identity.user.disabled", "identity.user.enabled", "identity.user.sessions-revoked", "identity.role.created",
+        "identity.role.permissions-replaced", "identity.user.role-assigned", "identity.user.role-removed", "identity.session.revoked"
+      ]
+    },
+    "schema_version": { "type": "integer", "const": 1 },
+    "occurred_at": { "type": "string", "format": "date-time" },
+    "producer_subsystem": { "type": "string", "enum": ["resource", "storage", "operations", "identity"] },
+    "actor": {
+      "type": ["object", "null"],
+      "properties": { "type": { "type": "string" }, "id": { "type": ["string", "null"], "format": "uuid" } },
+      "required": ["type"],
+      "additionalProperties": true
+    },
+    "subject": {
+      "type": ["object", "null"],
+      "properties": { "type": { "type": "string" }, "id": { "type": ["string", "null"], "format": "uuid" } },
+      "required": ["type"],
+      "additionalProperties": true
+    },
+    "correlation_id": { "type": ["string", "null"], "format": "uuid" },
+    "causation_id": { "type": ["string", "null"], "format": "uuid" },
+    "payload": { "type": "object" }
+  },
+  "allOf": [
+    { "if": { "properties": { "event_type": { "pattern": "^resource\\." } } }, "then": { "properties": { "producer_subsystem": { "const": "resource" } } } },
+    { "if": { "properties": { "event_type": { "pattern": "^storage\\." } } }, "then": { "properties": { "producer_subsystem": { "const": "storage" } } } },
+    { "if": { "properties": { "event_type": { "pattern": "^operations\\." } } }, "then": { "properties": { "producer_subsystem": { "const": "operations" } } } },
+    { "if": { "properties": { "event_type": { "pattern": "^identity\\." } } }, "then": { "properties": { "producer_subsystem": { "const": "identity" } } } }
+  ],
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary

Close the remaining P0 contract-convergence gaps before Phase 0 implementation starts.

### Added

- `P0-Implementation-Baseline.md`
  - formally accepts `v2-p0-foundation-0.2`
  - marks **Phase 0 Engineering Foundation = GO**
  - explicitly keeps Phase 1+ domains gated by their own Definition of Ready
- `P0-Requirement-Traceability-Matrix.md`
  - maps representative P0 PRD requirements through CQ/DB/API/Event/Test contracts
  - records known pre-Phase-1 contract expansion points
- `contracts/P0-HTTP-Operation-Registry.yaml`
  - machine mapping for all current **28 public P0 operations**
  - maps method/path/operationId back to Catalog contract IDs
- `api/openapi-v2-p0-contract-convergence.yaml`
  - additive OpenAPI contract for **12 Catalog-declared HTTP operations** missing from the original baseline
  - includes `x-ikaros-contract-id` on each new operation
- `contracts/schema/p0-event-v1.schema.json`
  - JSON Schema baseline for Event Envelope v1
  - locks UUIDv7 event ID, schema version, producer namespace, and the current **43 P0 v1 event types**

### Updated

- `P0-API-Contract-Coverage-Map.md`
  - documents base + convergence API coverage
  - distinguishes public HTTP from internal / `contract-deferred` Application Contracts
  - links the HTTP registry, traceability matrix, baseline, event schema, and acceptance gates

## Design decisions

- Do **not** expose every Application Command as HTTP just to improve coverage numbers.
- Preserve the existing `openapi-v2-p0.yaml` baseline and add missing mappings additively.
- Treat the HTTP Operation Registry as the machine mapping layer for existing + new operations.
- Keep Personal Drive and professional-domain implementation gated until their own Schema/CQ/Event/Permission/OpenAPI/Acceptance contracts are ready.
- Event payload field-level compatibility remains governed by the existing payload registry; Phase 0 implementation should turn those payload rules into executable compatibility fixtures/CI checks.

## Validation

- Public baseline: **16 existing + 12 convergence = 28 operations**.
- New OpenAPI operations map to existing Catalog Command/Query IDs.
- Event schema enumerates the current **43 P0 v1 event types** and enforces producer namespace alignment.
- No runtime/source-code changes are included.

## Result

After this PR, V2 can move from design-only work into **Phase 0 Engineering Foundation implementation**, while Phase 1+ domains remain independently gated.