### PR TITLE
docs(v2): 将 PR #888 新增 P0 契约文档中文化

### DIFF
--- a/docs/v2/P0-API-Contract-Coverage-Map.md
+++ b/docs/v2/P0-API-Contract-Coverage-Map.md
@@ -1,47 +1,47 @@
-# Ikaros V2 P0 API / Contract Coverage Map
+# Ikaros V2 P0 API / 契约覆盖映射
 
 | 项目 | 内容 |
 |---|---|
-| Baseline | `v2-p0-foundation-0.2` |
-| Base OpenAPI | `api/openapi-v2-p0.yaml` |
-| Convergence Addendum | `api/openapi-v2-p0-contract-convergence.yaml` |
-| Machine Registry | `contracts/P0-HTTP-Operation-Registry.yaml` |
-| Event Schema | `contracts/schema/p0-event-v1.schema.json` |
+| 基线 | `v2-p0-foundation-0.2` |
+| 基础 OpenAPI | `api/openapi-v2-p0.yaml` |
+| 契约收敛补充 | `api/openapi-v2-p0-contract-convergence.yaml` |
+| 机器可读注册表 | `contracts/P0-HTTP-Operation-Registry.yaml` |
+| 事件 Schema | `contracts/schema/p0-event-v1.schema.json` |
 
-> Application Contract exists ≠ public HTTP endpoint exists. Controller-first changes are prohibited.
+> 存在应用契约 ≠ 必须存在公开 HTTP 端点。禁止先写 Controller、后补契约。
 
-## Contract Files
+## 契约文件
 
-- `P0-Implementation-Baseline.md` — Phase 0 engineering GO / frozen boundary.
-- `P0-Requirement-Traceability-Matrix.md` — Requirement → Contract → DB → API → Event → Test traceability.
-- `contracts/P0-Command-Query-Event-Catalog.md` — Application Command / Query / Event authority.
-- `contracts/P0-Event-Payload-Schema-Registry.md` — human-readable event payload compatibility contract.
-- `contracts/schema/p0-event-v1.schema.json` — machine-readable Event Envelope / Type / Version baseline.
-- `contracts/P0-HTTP-Operation-Registry.yaml` — complete public P0 HTTP operation mapping.
-- `api/openapi-v2-p0.yaml` — original P0 OpenAPI baseline.
-- `api/openapi-v2-p0-contract-convergence.yaml` — additive coverage for Catalog-declared HTTP operations missing from the original spec.
-- `testing/P0-Acceptance-Invariant-Test-Matrix.md` — REQUIRED engineering gates.
+- `P0-Implementation-Baseline.md` — Phase 0 工程实现准入与冻结边界。
+- `P0-Requirement-Traceability-Matrix.md` — 需求 → 契约 → 数据库 → API → 事件 → 测试的可追溯关系。
+- `contracts/P0-Command-Query-Event-Catalog.md` — 应用层 Command / Query / Event 的权威目录。
+- `contracts/P0-Event-Payload-Schema-Registry.md` — 面向人的事件 Payload 兼容性契约。
+- `contracts/schema/p0-event-v1.schema.json` — 机器可读的事件 Envelope / Type / Version 基线。
+- `contracts/P0-HTTP-Operation-Registry.yaml` — 完整的 P0 公开 HTTP 操作映射。
+- `api/openapi-v2-p0.yaml` — 原始 P0 OpenAPI 基线。
+- `api/openapi-v2-p0-contract-convergence.yaml` — 对原始规范中缺失、但已由 Catalog 声明的 HTTP 操作进行增量补充。
+- `testing/P0-Acceptance-Invariant-Test-Matrix.md` — **必须满足**的工程验收门禁。
 
-## P0 Public API Rule
+## P0 公开 API 规则
 
 ```text
-Subsystem capability
-  -> Command or Query ID
-  -> Permission / authorization policy
+子系统能力
+  -> Command 或 Query ID
+  -> 权限 / 授权策略
   -> HTTP operationId
   -> HTTP Operation Registry
-  -> OpenAPI request/response schema
-  -> Event type/version (when durable fact exists)
-  -> Acceptance/invariant test
+  -> OpenAPI 请求 / 响应 Schema
+  -> Event type/version（产生持久事实时）
+  -> 验收 / 不变量测试
 ```
 
-CI should verify operationId uniqueness, method/path uniqueness, Registry → OpenAPI existence, Registry contract IDs → Catalog existence, and OpenAPI reference validity.
+CI 应校验：`operationId` 唯一性、method/path 唯一性、Registry → OpenAPI 的存在性、Registry 中的 contract ID → Catalog 的存在性，以及 OpenAPI 引用有效性。
 
-## Coverage After Convergence
+## 契约收敛后的覆盖情况
 
-The original OpenAPI baseline has **16** public operations. The convergence addendum adds **12** missing mappings, for **28** public P0 operations total.
+原始 OpenAPI 基线包含 **16** 个公开操作；契约收敛补充新增 **12** 个缺失映射，因此当前共有 **28** 个 P0 公开操作。
 
-Newly covered contracts:
+本轮新增覆盖的契约：
 
 - `resource.find-by-external-identity`
 - `resource.trash-resource`
@@ -56,31 +56,31 @@ Newly covered contracts:
 - `identity.list-sessions`
 - `identity.get-user`
 
-The exact machine list is `contracts/P0-HTTP-Operation-Registry.yaml`.
+精确的机器可读列表见 `contracts/P0-HTTP-Operation-Registry.yaml`。
 
-## Intentionally Not Public Yet
+## 当前明确不公开的能力
 
-The following Application Contracts remain internal or `contract-deferred` until route/request/response, authorization/step-up, idempotency and concurrency semantics are frozen:
+以下应用契约继续保持内部使用或 `contract-deferred` 状态，直到路由、请求/响应模型、授权/二次验证、幂等与并发语义完成冻结：
 
-- Resource mutation contracts for external identities, tags, collections and user-state;
-- Storage attachment lifecycle, blob verify/GC, provider update/enable/disable/drain;
-- `operations.retry-background-task`;
-- Identity user/role/session mutation commands not already in the base OpenAPI.
+- External Identity、Tag、Collection、User State 相关的 Resource 变更契约；
+- Storage Attachment 生命周期、Blob 校验/GC、Provider 更新/启用/禁用/排空；
+- `operations.retry-background-task`；
+- 基础 OpenAPI 尚未公开的 Identity 用户/角色/会话变更命令。
 
-Do not invent Controller routes for these capabilities.
+禁止为这些能力自行臆造 Controller 路由。
 
-## Event Machine Contract
+## 事件机器契约
 
-`contracts/schema/p0-event-v1.schema.json` locks the P0 event envelope, UUIDv7 event ID, schema version, producer namespace and the current **43 P0 v1 Event Types**. Per-event payload field constraints remain governed by `P0-Event-Payload-Schema-Registry.md` and must be expanded into machine compatibility checks during Phase 0 implementation (`P0-EVT-004/013/014`).
+`contracts/schema/p0-event-v1.schema.json` 冻结 P0 事件 Envelope、UUIDv7 Event ID、Schema Version、Producer Namespace，以及当前 **43 个 P0 v1 Event Type**。每种事件的 Payload 字段级约束仍由 `P0-Event-Payload-Schema-Registry.md` 管理，并应在 Phase 0 实现阶段扩展为机器可执行的兼容性检查（`P0-EVT-004/013/014`）。
 
-## Change Checklist
+## 变更检查清单
 
-- [ ] Catalog Command / Query exists.
-- [ ] Permission / object authorization is explicit.
-- [ ] OpenAPI operationId exists.
-- [ ] HTTP Operation Registry entry exists.
-- [ ] New/changed operation carries `x-ikaros-contract-id`.
-- [ ] Idempotency / concurrency semantics are explicit.
-- [ ] Event schema / payload registry is synchronized when applicable.
-- [ ] Acceptance Test ID exists.
-- [ ] Traceability Matrix is synchronized.
+- [ ] Catalog 中存在对应 Command / Query。
+- [ ] 权限 / 对象级授权规则明确。
+- [ ] OpenAPI 中存在对应 `operationId`。
+- [ ] HTTP Operation Registry 中存在对应条目。
+- [ ] 新增/变更操作携带 `x-ikaros-contract-id`。
+- [ ] 幂等 / 并发语义明确。
+- [ ] 适用时已同步 Event Schema / Payload Registry。
+- [ ] 存在对应 Acceptance Test ID。
+- [ ] 已同步 Traceability Matrix。

--- a/docs/v2/P0-Implementation-Baseline.md
+++ b/docs/v2/P0-Implementation-Baseline.md
@@ -1,28 +1,28 @@
-# Ikaros V2 P0 Engineering Foundation Contract Baseline
+# Ikaros V2 P0 工程基础契约基线
 
 | 项目 | 内容 |
 |---|---|
-| Baseline ID | `v2-p0-foundation-0.2` |
-| Baseline Date | 2026-09-02 |
-| 状态 | **Accepted for Phase 0 Engineering Foundation** |
-| 目标 | 允许 V2 从设计阶段进入 Phase 0 Engineering Foundation 实现 |
-| 非目标 | 不宣称 Phase 1+ 所有业务域已经冻结 |
+| 基线 ID | `v2-p0-foundation-0.2` |
+| 基线日期 | 2026-09-02 |
+| 状态 | **已接受，可进入 Phase 0 工程基础实现** |
+| 目标 | 允许 V2 从设计阶段进入 Phase 0 工程基础实现 |
+| 非目标 | 不表示 Phase 1+ 的所有业务域已经冻结 |
 
-> 本 Baseline 是“进入下一阶段”的工程 Gate 决议。它冻结 Phase 0 所需的基础契约，不把整个 V2 宣布为 Final。
+> 本基线是“进入下一阶段”的工程门禁决议。它冻结 Phase 0 所需的基础契约，但不代表整个 V2 已经最终定稿。
 
-## 1. Decision
+## 1. 决策
 
 ```text
-Phase 0 — Engineering Foundation = GO
-Phase 1+ Domain Implementation = gated per module Definition of Ready
-Release Readiness = NOT YET
+Phase 0 — 工程基础 = GO
+Phase 1+ 领域实现 = 按各模块的 Definition of Ready 独立门禁
+发布就绪状态 = 尚未达到
 ```
 
-下一阶段默认产出应转向 module skeleton、Flyway、Application API、Outbox/Inbox、Background Task runtime 与自动化测试，而不是继续横向增加 P0 设计文档。
+下一阶段的默认产出应转向模块骨架、Flyway、Application API、Outbox/Inbox、Background Task Runtime 与自动化测试，而不是继续横向增加 P0 设计文档。
 
-## 2. Normative Baseline Set
+## 2. 规范性基线集合
 
-Phase 0 实现至少以以下文档为输入：
+Phase 0 实现至少应以下列文档作为输入：
 
 - `Product-Requirements-Document.md`
 - `System-Overview-Design.md`
@@ -43,62 +43,62 @@ Phase 0 实现至少以以下文档为输入：
 
 Media Delivery / Restore 的独立 P0 Addendum 继续作为专项规范性扩展。
 
-## 3. Frozen Foundation Rules
+## 3. 已冻结的基础规则
 
-没有先修改设计/ADR 时，Phase 0 实现不得自行改变：
+如果没有先修改设计文档或 ADR，Phase 0 实现不得自行改变：
 
-- UUID public identity policy；
-- PostgreSQL owner schema boundary；
-- Resource / Attachment / Blob / Placement identity separation；
-- optimistic concurrency semantics；
-- Command / Query application boundary；
-- Outbox + Inbox atomicity / at-least-once / consumer idempotency；
-- Background Task / Attempt separation；
-- Permission Registry authority 与对象级授权边界；
-- Secret Reference boundary；
+- UUID 公开身份标识策略；
+- PostgreSQL Owner Schema 边界；
+- Resource / Attachment / Blob / Placement 的身份分离；
+- 乐观并发控制语义；
+- Command / Query 应用层边界；
+- Outbox + Inbox 的原子性、至少一次投递与消费者幂等语义；
+- Background Task / Attempt 分离；
+- Permission Registry 的权威性与对象级授权边界；
+- Secret Reference 边界；
 - `/api/v2`、Problem、snake_case、Idempotency、ETag/If-Match、Range 等 API 规则；
-- Plugin private persistence boundary。
+- Plugin 私有持久化边界。
 
-## 4. Not Frozen Yet
+## 4. 尚未冻结的内容
 
-本 Baseline 不表示以下内容可以无条件并行编码：
+本基线不表示以下内容可以无条件并行编码：
 
-- Personal Drive full Schema / API / Event mapping；
-- Media / Reading / Music / Photo / Game / Document 全量专业领域 contract；
-- Productivity / Finance / Secure Domain 完整持久化与 public API；
-- V1 → V2 migration strategy；
-- production capacity / partition quantitative baseline；
-- 每个 Catalog Command 的 HTTP route。
+- Personal Drive 的完整 Schema / API / Event 映射；
+- Media / Reading / Music / Photo / Game / Document 的全量专业领域契约；
+- Productivity / Finance / Secure Domain 的完整持久化与公开 API；
+- V1 → V2 迁移策略；
+- 生产容量 / 分区的量化基线；
+- 每个 Catalog Command 对应的 HTTP 路由。
 
 ```text
-Application Contract exists != Public HTTP endpoint must exist
+存在应用契约 != 必须存在公开 HTTP 端点
 ```
 
-未进入 OpenAPI / HTTP Registry 的 Command 不允许由 Controller 自行猜测路由。
+未进入 OpenAPI / HTTP Registry 的 Command，不允许由 Controller 自行猜测路由。
 
-## 5. Phase 0 Implementation Outputs
+## 5. Phase 0 实现产出
 
 建议按以下顺序推进：
 
 ```text
-Module Skeleton
- -> Architecture Boundary Tests
- -> Flyway P0 Foundation Schema
+模块骨架
+ -> 架构边界测试
+ -> Flyway P0 基础 Schema
  -> UUIDv7 / Clock / Problem / Principal
  -> Transaction + Outbox / Inbox
  -> Background Task Runtime
- -> Resource / Storage / Identity Application APIs
- -> OpenAPI Controllers / DTOs
- -> Contract / Recovery / Concurrency / Security Tests
- -> P0 E2E Gates
+ -> Resource / Storage / Identity Application API
+ -> OpenAPI Controller / DTO
+ -> 契约 / 恢复 / 并发 / 安全测试
+ -> P0 E2E 门禁
 ```
 
-## 6. Follow-up Gates
+## 6. 后续门禁
 
-Phase 1 Resource Core 对应能力实现前，至少补齐 Collection hierarchy、Resource Relation、必要的 Title/Alias mutation，以及当前 `contract-deferred` 的 public mutation surface。
+Phase 1 Resource Core 对应能力实现前，至少补齐 Collection 层级关系、Resource Relation、必要的 Title/Alias 变更能力，以及当前处于 `contract-deferred` 状态的公开变更接口。
 
-Personal Drive 和每个 Professional Domain 仍必须分别具备 Schema + Command/Query + Event + Permission + OpenAPI（适用时）+ Acceptance Matrix，才能进入其模块编码。
+Personal Drive 和每个 Professional Domain 仍必须分别具备 Schema + Command/Query + Event + Permission + OpenAPI（适用时）+ Acceptance Matrix，才能进入对应模块的编码阶段。
 
-## 7. Change Control
+## 7. 变更控制
 
-实现发现契约问题时：先修改 Source of Truth / ADR 与测试契约，再改代码。禁止通过 Controller special-case、跨 Schema 私写、Repository hidden rule 或“先写代码后补契约”绕过 Gate。
+实现过程中发现契约问题时，应先修改事实来源文档（Source of Truth）/ ADR 与测试契约，再修改代码。禁止通过 Controller 特例、跨 Schema 私写、Repository 隐式规则，或“先写代码、后补契约”的方式绕过门禁。

--- a/docs/v2/P0-Requirement-Traceability-Matrix.md
+++ b/docs/v2/P0-Requirement-Traceability-Matrix.md
@@ -1,64 +1,64 @@
-# Ikaros V2 P0 Requirement / Contract Traceability Matrix
+# Ikaros V2 P0 需求 / 契约可追溯矩阵
 
 | 项目 | 内容 |
 |---|---|
-| Baseline | `v2-p0-foundation-0.2` |
-| 状态 | Accepted / Engineering Traceability Baseline |
+| 基线 | `v2-p0-foundation-0.2` |
+| 状态 | 已接受 / 工程可追溯基线 |
 | PRD | `Product-Requirements-Document.md` |
-| Catalog | `contracts/P0-Command-Query-Event-Catalog.md` |
-| Database | `database/P0-Database-Schema-Design.md` |
+| 契约目录 | `contracts/P0-Command-Query-Event-Catalog.md` |
+| 数据库 | `database/P0-Database-Schema-Design.md` |
 | OpenAPI | `api/openapi-v2-p0.yaml` + `api/openapi-v2-p0-contract-convergence.yaml` |
-| HTTP Registry | `contracts/P0-HTTP-Operation-Registry.yaml` |
-| Acceptance | `testing/P0-Acceptance-Invariant-Test-Matrix.md` |
+| HTTP 注册表 | `contracts/P0-HTTP-Operation-Registry.yaml` |
+| 验收测试 | `testing/P0-Acceptance-Invariant-Test-Matrix.md` |
 
-> 本矩阵冻结 P0 Engineering Foundation / Core Platform 首批实现切片，不提前伪造 Phase 1+ 专业领域尚未冻结的 Schema/API。
+> 本矩阵冻结 P0 Engineering Foundation / Core Platform 的首批实现切片，不提前伪造 Phase 1+ 专业领域中尚未冻结的 Schema/API。
 
-## 1. Traceability Rule
+## 1. 可追溯规则
 
 ```text
-PRD / System Requirement
- -> Subsystem Invariant
+PRD / 系统需求
+ -> 子系统不变量
  -> Command / Query
- -> Permission / Security Policy
- -> DB Constraint / Transaction Boundary
+ -> 权限 / 安全策略
+ -> 数据库约束 / 事务边界
  -> HTTP operation（公开时）
- -> Durable Event（产生事实时）
+ -> Durable Event（产生持久事实时）
  -> Acceptance Test ID
 ```
 
-所有 public HTTP operation 必须进入 `contracts/P0-HTTP-Operation-Registry.yaml`。本轮新增 operation 还必须在 OpenAPI 中携带 `x-ikaros-contract-id`。
+所有公开 HTTP operation 都必须登记到 `contracts/P0-HTTP-Operation-Registry.yaml`。本轮新增 operation 还必须在 OpenAPI 中携带 `x-ikaros-contract-id`。
 
-## 2. P0 Traceability Slice
+## 2. P0 可追溯切片
 
-| Requirement | Contract | DB / Transaction | Public HTTP | Event | Acceptance |
+| 需求 | 契约 | 数据库 / 事务 | 公开 HTTP | 事件 | 验收 |
 |---|---|---|---|---|---|
-| `FR-LIB-01` Resource 浏览 | `resource.list-resources`, `resource.get-resource` | `resource.resource` | `listResources`, `getResource` | read-only | `P0-RES-001`, `P0-API-004`, `P0-SEC-004/005` |
-| `FR-LIB-03` Collection | create/add/remove/list collection contracts | `resource.collection`, `resource.collection_member` | `listCollections` | `resource.collection.*` | `P0-RES-021~024`, `P0-CON-004` |
-| `FR-LIB-05` 多标题 | create resource / title query | `resource.resource_title` | initial titles embedded in `createResource` | `resource.resource.created` | `P0-RES-011` |
-| `FR-LIB-06` External Identity | attach/detach/find | `resource.external_identity` unique key | `findResourceByExternalIdentity` | `resource.external-identity.*` | `P0-RES-016~018`, `P0-CON-002` |
-| Resource lifecycle | archive/restore/trash | resource version + outbox transaction | `archiveResource`, `restoreResource`, `trashResource` | lifecycle events | `P0-RES-003~010`, `P0-CON-001` |
-| User Resource State | set/get state | `resource.user_resource_state` | `getResourceUserState` | `resource.user-state.changed` | `P0-RES-027~029` |
-| `FR-STORAGE-01` Attachment / Blob 解耦 | attachment create/read/content | attachment + blob + placement | `getAttachment`, `getAttachmentContent` | `storage.attachment.*` | `P0-STO-001~007`, `P0-API-013` |
-| `FR-STORAGE-02` 多级对象存储 | provider/placement contracts | provider + placement | list/get providers, placements | `storage.provider.*` | `P0-STO-006/007/018/019` |
-| `FR-STORAGE-06` 内容完整性 | `storage.verify-blob` | blob integrity state | internal / async | verified / integrity-failed | `P0-STO-008~010`, `P0-REC-007` |
-| Blob GC safety | `storage.request-blob-gc` | reference recheck + background task | contract-deferred | gc-requested / purged | `P0-STO-011~015`, `P0-CON-007` |
-| Background Task | get/list/attempts/cancel/retry | Task + immutable Attempt history | get/list/attempts/cancel | `operations.background-task.*` | `P0-TASK-001~012`, recovery gates |
-| `FR-AUTH-01` Identity | current-user/session contracts | user + session digest/security_version | `getCurrentUser`, `listSessions` | identity/session events | `P0-ID-009~014` |
-| `FR-AUTH-02` Authorization | role/permission/user contracts | permission/role/binding tables | users/roles/permissions queries | role/user events | `P0-ID-004~008`, `P0-API-014` |
-| Durable Event | Event Envelope + producer/consumer matrix | outbox + inbox atomicity | N/A | 43 P0 v1 event types | `P0-EVT-001~014`, `P0-REC-001~005` |
-| `FR-PLUGIN-01/02` Plugin boundary | runtime/capability/permission contracts | plugin-owned persistence boundary | N/A | capability-mediated only | `P0-PLG-001~008`, `P0-SEC-008` |
+| `FR-LIB-01` Resource 浏览 | `resource.list-resources`, `resource.get-resource` | `resource.resource` | `listResources`, `getResource` | 只读 | `P0-RES-001`, `P0-API-004`, `P0-SEC-004/005` |
+| `FR-LIB-03` Collection | Collection 创建/添加/移除/列表契约 | `resource.collection`, `resource.collection_member` | `listCollections` | `resource.collection.*` | `P0-RES-021~024`, `P0-CON-004` |
+| `FR-LIB-05` 多标题 | Resource 创建 / Title 查询 | `resource.resource_title` | 初始标题内嵌在 `createResource` | `resource.resource.created` | `P0-RES-011` |
+| `FR-LIB-06` External Identity | 绑定/解绑/查找 | `resource.external_identity` 唯一键 | `findResourceByExternalIdentity` | `resource.external-identity.*` | `P0-RES-016~018`, `P0-CON-002` |
+| Resource 生命周期 | 归档/恢复/移入回收站 | Resource Version + Outbox 事务 | `archiveResource`, `restoreResource`, `trashResource` | 生命周期事件 | `P0-RES-003~010`, `P0-CON-001` |
+| 用户 Resource 状态 | 设置/获取状态 | `resource.user_resource_state` | `getResourceUserState` | `resource.user-state.changed` | `P0-RES-027~029` |
+| `FR-STORAGE-01` Attachment / Blob 解耦 | Attachment 创建/读取/内容访问 | Attachment + Blob + Placement | `getAttachment`, `getAttachmentContent` | `storage.attachment.*` | `P0-STO-001~007`, `P0-API-013` |
+| `FR-STORAGE-02` 多级对象存储 | Provider/Placement 契约 | Provider + Placement | Provider、Placement 的 list/get | `storage.provider.*` | `P0-STO-006/007/018/019` |
+| `FR-STORAGE-06` 内容完整性 | `storage.verify-blob` | Blob 完整性状态 | 内部 / 异步 | verified / integrity-failed | `P0-STO-008~010`, `P0-REC-007` |
+| Blob GC 安全 | `storage.request-blob-gc` | 引用复核 + Background Task | `contract-deferred` | gc-requested / purged | `P0-STO-011~015`, `P0-CON-007` |
+| Background Task | get/list/attempts/cancel/retry | Task + 不可变 Attempt 历史 | get/list/attempts/cancel | `operations.background-task.*` | `P0-TASK-001~012`、恢复类门禁 |
+| `FR-AUTH-01` Identity | Current User / Session 契约 | User + Session Digest / Security Version | `getCurrentUser`, `listSessions` | Identity / Session 事件 | `P0-ID-009~014` |
+| `FR-AUTH-02` Authorization | Role / Permission / User 契约 | Permission / Role / Binding 表 | Users/Roles/Permissions 查询 | Role/User 事件 | `P0-ID-004~008`, `P0-API-014` |
+| Durable Event | Event Envelope + Producer/Consumer 矩阵 | Outbox + Inbox 原子性 | N/A | 43 个 P0 v1 Event Type | `P0-EVT-001~014`, `P0-REC-001~005` |
+| `FR-PLUGIN-01/02` Plugin 边界 | Runtime/Capability/Permission 契约 | Plugin 自有持久化边界 | N/A | 仅通过 Capability 中介 | `P0-PLG-001~008`, `P0-SEC-008` |
 
-## 3. Known Pre-Phase-1 Expansion
+## 3. Phase 1 前已知需补充的内容
 
 对应功能开工前必须补齐：
 
 - Collection hierarchy mutation；
 - Resource Relation mutation/query；
 - 独立 Title/Alias mutation（若首批 UI 需要）；
-- 当前 `contract-deferred` 的 public mutation surface。
+- 当前 `contract-deferred` 的公开 mutation surface。
 
 Personal Drive 与各 Professional Domain 仍必须分别满足 Roadmap Definition of Ready：Schema + Command/Query + Event + Permission + OpenAPI（公开时）+ Acceptance。
 
-## 4. Change Rule
+## 4. 变更规则
 
-P0 语义变更必须同步所有适用层。暂不适用时明确写 `N/A` 或 `contract-deferred`，不得把空白解释为实现自由。
+P0 语义变更必须同步所有适用层。暂不适用时应明确写 `N/A` 或 `contract-deferred`，不得把空白解释为“实现可以自行决定”。

--- a/docs/v2/api/openapi-v2-p0-contract-convergence.yaml
+++ b/docs/v2/api/openapi-v2-p0-contract-convergence.yaml
@@ -1,8 +1,8 @@
 openapi: 3.1.0
 info:
-  title: Ikaros V2 P0 Contract Convergence API Addendum
+  title: Ikaros V2 P0 契约收敛 API 补充规范
   version: 0.1.0
-  description: Additive HTTP contracts declared by the P0 Catalog but absent from the original P0 OpenAPI baseline.
+  description: 对 P0 Catalog 已声明、但原始 P0 OpenAPI 基线中缺失的 HTTP 契约进行增量补充。
 servers:
   - url: /api/v2
 security:
@@ -18,7 +18,7 @@ paths:
         - { name: object_type, in: query, required: true, schema: { type: string } }
         - { name: external_id, in: query, required: true, schema: { type: string } }
       responses:
-        '200': { description: Matched resource, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/Resource' } } } }
+        '200': { description: 匹配到的资源, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/Resource' } } } }
         '404': { $ref: './openapi-v2-p0.yaml#/components/responses/NotFound' }
   /resources/{resource_id}/actions/trash:
     parameters:
@@ -29,7 +29,7 @@ paths:
       parameters:
         - { $ref: './openapi-v2-p0.yaml#/components/parameters/IfMatch' }
       responses:
-        '200': { description: Trashed resource, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/Resource' } } } }
+        '200': { description: 已移入回收站的资源, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/Resource' } } } }
         '412': { $ref: './openapi-v2-p0.yaml#/components/responses/PreconditionFailed' }
         '428': { $ref: './openapi-v2-p0.yaml#/components/responses/PreconditionRequired' }
   /resources/{resource_id}/user-state:
@@ -39,7 +39,7 @@ paths:
       operationId: getResourceUserState
       x-ikaros-contract-id: resource.get-user-state
       responses:
-        '200': { description: Current user state, content: { application/json: { schema: { $ref: '#/components/schemas/UserResourceState' } } } }
+        '200': { description: 当前用户状态, content: { application/json: { schema: { $ref: '#/components/schemas/UserResourceState' } } } }
   /tags:
     get:
       operationId: listTags
@@ -48,7 +48,7 @@ paths:
         - { $ref: './openapi-v2-p0.yaml#/components/parameters/Cursor' }
         - { $ref: './openapi-v2-p0.yaml#/components/parameters/Limit' }
       responses:
-        '200': { description: Tag page, content: { application/json: { schema: { $ref: '#/components/schemas/Page' } } } }
+        '200': { description: 标签分页结果, content: { application/json: { schema: { $ref: '#/components/schemas/Page' } } } }
   /collections:
     get:
       operationId: listCollections
@@ -57,7 +57,7 @@ paths:
         - { $ref: './openapi-v2-p0.yaml#/components/parameters/Cursor' }
         - { $ref: './openapi-v2-p0.yaml#/components/parameters/Limit' }
       responses:
-        '200': { description: Collection page, content: { application/json: { schema: { $ref: '#/components/schemas/Page' } } } }
+        '200': { description: Collection 分页结果, content: { application/json: { schema: { $ref: '#/components/schemas/Page' } } } }
   /background-tasks:
     get:
       operationId: listBackgroundTasks
@@ -68,7 +68,7 @@ paths:
         - { name: status, in: query, schema: { type: string } }
         - { name: task_type, in: query, schema: { type: string } }
       responses:
-        '200': { description: Background task page, content: { application/json: { schema: { $ref: '#/components/schemas/Page' } } } }
+        '200': { description: 后台任务分页结果, content: { application/json: { schema: { $ref: '#/components/schemas/Page' } } } }
   /background-tasks/{task_id}/attempts:
     parameters:
       - { $ref: './openapi-v2-p0.yaml#/components/parameters/TaskId' }
@@ -76,7 +76,7 @@ paths:
       operationId: listBackgroundTaskAttempts
       x-ikaros-contract-id: operations.list-task-attempts
       responses:
-        '200': { description: Attempt history, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/BackgroundTaskAttempt' } } } } }
+        '200': { description: 任务尝试历史, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/BackgroundTaskAttempt' } } } } }
   /admin/blobs/{blob_id}/placements:
     parameters:
       - { name: blob_id, in: path, required: true, schema: { type: string, format: uuid } }
@@ -84,7 +84,7 @@ paths:
       operationId: listBlobPlacements
       x-ikaros-contract-id: storage.list-blob-placements
       responses:
-        '200': { description: Blob placements, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/BlobPlacement' } } } } }
+        '200': { description: Blob 存储位置列表, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/BlobPlacement' } } } } }
   /admin/storage-providers/{provider_id}:
     parameters:
       - { name: provider_id, in: path, required: true, schema: { type: string, format: uuid } }
@@ -92,19 +92,19 @@ paths:
       operationId: getStorageProvider
       x-ikaros-contract-id: storage.get-provider
       responses:
-        '200': { description: Storage provider, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/StorageProvider' } } } }
+        '200': { description: 存储提供方, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/StorageProvider' } } } }
   /me:
     get:
       operationId: getCurrentUser
       x-ikaros-contract-id: identity.get-current-user
       responses:
-        '200': { description: Current user, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/User' } } } }
+        '200': { description: 当前用户, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/User' } } } }
   /me/sessions:
     get:
       operationId: listSessions
       x-ikaros-contract-id: identity.list-sessions
       responses:
-        '200': { description: Sessions, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/SessionSummary' } } } } }
+        '200': { description: 会话列表, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/SessionSummary' } } } } }
   /admin/users/{user_id}:
     parameters:
       - { name: user_id, in: path, required: true, schema: { type: string, format: uuid } }
@@ -112,7 +112,7 @@ paths:
       operationId: getUser
       x-ikaros-contract-id: identity.get-user
       responses:
-        '200': { description: User, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/User' } } } }
+        '200': { description: 用户, content: { application/json: { schema: { $ref: './openapi-v2-p0.yaml#/components/schemas/User' } } } }
 components:
   securitySchemes:
     bearerAuth: { type: http, scheme: bearer }

--- a/docs/v2/contracts/schema/p0-event-v1.schema.json
+++ b/docs/v2/contracts/schema/p0-event-v1.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ikaros.run/schemas/v2/p0-event-v1.schema.json",
-  "title": "Ikaros V2 P0 Durable Event v1",
-  "description": "Machine-readable P0 event envelope/type baseline. Payload field compatibility remains governed by P0-Event-Payload-Schema-Registry.md and is expanded into per-event schemas during Phase 0 implementation.",
+  "title": "Ikaros V2 P0 持久事件 v1",
+  "description": "P0 事件 Envelope / Type 的机器可读基线。Payload 字段兼容性仍由 P0-Event-Payload-Schema-Registry.md 管理，并在 Phase 0 实现阶段逐步扩展为每种事件对应的 Schema。",
   "type": "object",
   "required": ["event_id", "event_type", "schema_version", "occurred_at", "producer_subsystem", "payload"],
   "properties": {


### PR DESCRIPTION
## 背景

PR #888 合入的 P0 契约收敛文档中，大量面向人的说明文字仍为英文，与 `docs/v2` 当前中文文档风格不一致。

## 本次调整

- 将 `P0-API-Contract-Coverage-Map.md` 的标题、说明、规则、覆盖情况与检查清单改为中文。
- 将 `P0-Implementation-Baseline.md` 的工程基线说明、决策、冻结规则、实现产出与变更控制改为中文。
- 将 `P0-Requirement-Traceability-Matrix.md` 的可追溯规则、矩阵说明与变更规则改为中文。
- 将 `openapi-v2-p0-contract-convergence.yaml` 中面向人的 `title`、`description` 与 response description 改为中文。
- 将 `p0-event-v1.schema.json` 中面向人的 `title`、`description` 改为中文。

## 保持不变

为避免破坏契约兼容性，以下机器可读标识保持原样：

- HTTP path / method
- `operationId`
- `x-ikaros-contract-id`
- Command / Query / Event ID
- Event Type
- JSON Schema 字段名与枚举值
- `P0-HTTP-Operation-Registry.yaml` 的机器映射内容

## 结果

PR #888 新增的 P0 契约文档现在以中文作为主要说明语言，同时不改变任何运行时或机器契约语义。