### PR TITLE
fix(storage): remove preview storage fallback

### DIFF
--- a/src/main/java/run/ikaros/storage/AttachmentPreviewService.java
+++ b/src/main/java/run/ikaros/storage/AttachmentPreviewService.java
@@ -14,7 +14,6 @@ public class AttachmentPreviewService {
     private final BlobRepository blobs;
     private final BlobPlacementRepository placements;
     private final StorageProviderRegistry providers;
-    private final StorageObjectProviderRegistry objects;
     private final MediaDeliveryBindingRepository bindings;
     private final DeliveryProviderRepository deliveryProviders;
     private final DeliveryGrantService deliveryGrants;
@@ -23,11 +22,11 @@ public class AttachmentPreviewService {
 
     public AttachmentPreviewService(AttachmentRepository attachments, ResourceRepository resources, BlobRepository blobs,
                                      BlobPlacementRepository placements, StorageProviderRegistry providers,
-                                     StorageObjectProviderRegistry objects, MediaDeliveryBindingRepository bindings,
+                                     MediaDeliveryBindingRepository bindings,
                                      DeliveryProviderRepository deliveryProviders, DeliveryGrantService deliveryGrants,
                                      DeliveryLeaseService deliveryLeases, DeliveryGrantContractService deliveryContracts) {
         this.attachments = attachments; this.resources = resources; this.blobs = blobs; this.placements = placements;
-        this.providers = providers; this.objects = objects; this.bindings = bindings; this.deliveryProviders = deliveryProviders;
+        this.providers = providers; this.bindings = bindings; this.deliveryProviders = deliveryProviders;
         this.deliveryGrants = deliveryGrants;
         this.deliveryLeases = deliveryLeases; this.deliveryContracts = deliveryContracts;
     }
@@ -39,8 +38,7 @@ public class AttachmentPreviewService {
             .flatMap(attachment -> blobs.findById(attachment.blobId())
                 .switchIfEmpty(Mono.error(new NotFoundException("Attachment 对应的 Blob 不存在")))
                 .flatMap(blob -> preferDeliveryBinding(actorId, attachmentId, blob)
-                    .switchIfEmpty(Mono.defer(() -> fallbackToStorage(blob)))
-                    .switchIfEmpty(Mono.error(new StorageUnavailableException("附件没有可用存储 Placement")))));
+                    .switchIfEmpty(Mono.error(new StorageUnavailableException("附件没有可用 Delivery Binding")))));
     }
 
     private Mono<AttachmentPreviewUrlView> preferDeliveryBinding(UUID actorId, UUID attachmentId, BlobEntity blob) {
@@ -79,15 +77,5 @@ public class AttachmentPreviewService {
                 .onErrorResume(error -> deliveryGrants.revoke(actorId, grant.id())
                     .onErrorResume(revokeError -> Mono.empty())
                     .then(Mono.error(error))));
-    }
-
-    private Mono<AttachmentPreviewUrlView> fallbackToStorage(BlobEntity blob) {
-        return placements.findAllByBlobIdOrderByCreatedAtAsc(blob.id())
-                    .filter(placement -> placement.placementState() == PlacementState.ACTIVE)
-                    .concatMap(placement -> providers.getByKey(placement.provider())
-                        .flatMap(provider -> objects.createReadIntent(provider, placement.objectKey())
-                            .map(intent -> new AttachmentPreviewUrlView(intent.method(), intent.url(), intent.expiresAt(), true,
-                                blob.mediaType()))))
-                    .next();
     }
 }

--- a/src/test/java/run/ikaros/storage/AttachmentPreviewServiceTest.java
+++ b/src/test/java/run/ikaros/storage/AttachmentPreviewServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import run.ikaros.common.StorageUnavailableException;
 import run.ikaros.resource.ResourceEntity;
 import run.ikaros.resource.ResourceRepository;
 
@@ -20,7 +21,6 @@ class AttachmentPreviewServiceTest {
     private final BlobRepository blobs = mock(BlobRepository.class);
     private final BlobPlacementRepository placements = mock(BlobPlacementRepository.class);
     private final StorageProviderRegistry providers = mock(StorageProviderRegistry.class);
-    private final StorageObjectProviderRegistry objects = mock(StorageObjectProviderRegistry.class);
     private final MediaDeliveryBindingRepository bindings = mock(MediaDeliveryBindingRepository.class);
     private final DeliveryProviderRepository deliveryProviders = mock(DeliveryProviderRepository.class);
     private final DeliveryGrantService grants = mock(DeliveryGrantService.class);
@@ -39,7 +39,7 @@ class AttachmentPreviewServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new AttachmentPreviewService(attachments, resources, blobs, placements, providers, objects,
+        service = new AttachmentPreviewService(attachments, resources, blobs, placements, providers,
             bindings, deliveryProviders, grants, leases, contracts);
         actorId = UUID.randomUUID(); attachmentId = UUID.randomUUID(); blobId = UUID.randomUUID();
         resourceId = UUID.randomUUID(); storageProviderId = UUID.randomUUID();
@@ -58,7 +58,7 @@ class AttachmentPreviewServiceTest {
     }
 
     @Test
-    void prefersDeliveryBindingOverStorageSignedUrl() {
+    void prefersDeliveryBinding() {
         MediaDeliveryBindingEntity binding = new MediaDeliveryBindingEntity(UUID.randomUUID(), storageProviderId, "cdn",
             DeliveryBindingOriginType.STORAGE_PROVIDER, DeliveryBindingAuthMode.DELIVERY_GRANT, 1, true,
             DeliveryBindingCacheKeyPolicy.CONTENT_IDENTITY, DeliveryBindingRangePolicy.PASSTHROUGH, true,
@@ -82,22 +82,18 @@ class AttachmentPreviewServiceTest {
         StepVerifier.create(service.issue(actorId, attachmentId))
             .assertNext(result -> assertThat(result.url()).contains("delivery_grant=token"))
             .verifyComplete();
-        verifyNoInteractions(objects);
     }
 
     @Test
-    void fallsBackToStorageSignedUrlWhenNoDeliveryBindingExists() {
+    void rejectsPreviewWhenNoDeliveryBindingExists() {
         when(bindings.findAllByStorageProviderIdOrderByPriorityAsc(storageProviderId)).thenReturn(Flux.empty());
-        StorageReadIntent intent = new StorageReadIntent("GET", "https://storage.example/video.mp4?signature=x",
-            Instant.now().plusSeconds(60));
-        when(objects.createReadIntent(provider, "video.mp4")).thenReturn(Mono.just(intent));
 
         StepVerifier.create(service.issue(actorId, attachmentId))
-            .assertNext(result -> {
-                assertThat(result.url()).startsWith("https://storage.example");
-                assertThat(result.rangeSupported()).isTrue();
+            .expectErrorSatisfies(error -> {
+                assertThat(error).isInstanceOf(StorageUnavailableException.class);
+                assertThat(error).hasMessage("附件没有可用 Delivery Binding");
             })
-            .verifyComplete();
+            .verify();
         verifyNoInteractions(grants, leases, contracts);
     }
 }


### PR DESCRIPTION
## Summary
- remove attachment preview fallback to storage-provider presigned URLs when no delivery binding is configured
- require a usable Delivery Binding for preview URL issuance
- remove the now-unused storage object provider dependency from `AttachmentPreviewService`
- update tests to assert preview issuance fails when no delivery binding exists

## Rationale
Storage Provider and Delivery Provider have separate responsibilities. Falling back to the Storage Provider's presigned URL implicitly turns storage access into a delivery path and violates the delivery design. When no Delivery Provider/Binding is available, preview issuance should fail explicitly instead of bypassing the delivery layer.

## Validation
- branch is based on latest `main` (`52f45924e44f1d0696938691dad5d9c41ec77afd`)
- diff is limited to `AttachmentPreviewService` and `AttachmentPreviewServiceTest`
- regression test covers the no-binding case and expects `StorageUnavailableException`