### PR TITLE
docs: align V2 engineering baseline with Maven and r2dbc-migrate

### DIFF
--- a/docs/00-product-baseline/Engineering-Implementation-Index.md
+++ b/docs/00-product-baseline/Engineering-Implementation-Index.md
@@ -34,11 +34,11 @@
 
 - Java 21 / Spring Boot 4.x / WebFlux / Reactor / R2DBC 的默认技术路径；
 - Server / Worker 运行时拓扑；
-- Gradle API / Impl 编译期隔离；
+- 根 `pom.xml` 单模块 Maven 构建与 Java Package / ArchUnit 模块边界；
 - Spring Composition Root 与 Bean 可见性；
 - Reactive Event Loop / Blocking Adapter 规则；
 - Reactive Transaction 与 PostgreSQL Schema Ownership；
-- Flyway + JDBC Migration 与 R2DBC Runtime 分离；
+- `r2dbc-migrate` 与业务 R2DBC Runtime 的职责分离，并保持单一 R2DBC 数据库访问栈；
 - Outbox / Inbox、Background Task / Lease 的工程落地；
 - Cache / Search / Analytics / AI Projection 边界；
 - Blob Streaming / Range、大文件内存约束；
@@ -106,7 +106,7 @@
 - Event Outbox / Consumer Inbox；
 - Background Task / Attempt；
 - Identity / Permission / Role / Session；
-- 字段、Constraint、Index、Transaction Boundary 与首批 Flyway 顺序。
+- 字段、Constraint、Index、Transaction Boundary 与首批 `r2dbc-migrate` 顺序。
 
 它回答：
 
@@ -178,7 +178,7 @@ OpenAPI Contract
       ↓
 Acceptance / Invariant Test Matrix
       ↓
-Flyway Migration
+r2dbc-migrate Migration
       ↓
 Module Skeleton
       ↓
@@ -211,10 +211,10 @@ Automated Contract / Integration / E2E Tests
 
 ### P0 Implementation
 
-- Platform Foundation module skeleton；
-- Resource / Storage / Identity / Integration / Operations module skeleton；
-- Gradle `api` / `impl` 编译隔离和 ArchUnit 边界测试；
-- 首批 Flyway V2 migrations；
+- 单 Maven 工程中的 Platform Foundation module skeleton；
+- 单 Maven 工程中的 Resource / Storage / Identity / Integration / Operations module skeleton；
+- Java Package Ownership + ArchUnit 边界测试，不依赖构建子模块提供编译隔离；
+- 首批 `r2dbc-migrate` V2 migrations；
 - Permission Registry / Built-in Role deterministic seed；
 - Resource / Storage Application Command / Query handlers；
 - Reactive transaction executor；

--- a/docs/00-product-baseline/Module-Package-Ownership-Design.md
+++ b/docs/00-product-baseline/Module-Package-Ownership-Design.md
@@ -9,7 +9,7 @@
 
 > 本文档将 V2 的模块化单体原则落实为代码所有权、依赖方向与可见性边界。
 >
-> 目标不是提前锁死最终目录名，而是确保每个领域在 Java / Gradle / Persistence 层都有唯一 Owner，并阻止跨模块通过 Entity、Repository、SQL 或私有实现产生隐式耦合。
+> 目标不是提前锁死最终目录名，而是确保每个领域在 Java Package / Spring / Persistence 层都有唯一 Owner，并阻止跨模块通过 Entity、Repository、SQL 或私有实现产生隐式耦合。
 
 ---
 
@@ -30,7 +30,7 @@ V2 采用 Modular Monolith。模块化单体必须同时满足：
 3. 模块之间允许依赖什么；
 4. 哪些依赖明确禁止；
 5. API、Application、Domain、Persistence 如何分层；
-6. Gradle Module 与 Java Package 如何表达边界。
+6. 单 Maven 工程中的 Java Package 与 Spring 组装如何表达和强制模块边界。
 
 ---
 
@@ -72,7 +72,7 @@ ikaros-v2
 └── password-manager
 ```
 
-具体是否每个逻辑模块都对应独立 Gradle subproject，可以在实施时根据编译隔离收益决定；但无论是否独立 subproject，**逻辑边界与依赖规则都必须保持一致**。
+P0 以上述内容作为**逻辑模块拓扑**，统一位于根 `pom.xml` 的单 Maven 工程中，不要求、也不应自行拆成 Gradle 或 Maven subproject。无论物理目录如何组织，**逻辑边界与依赖规则都必须通过 Java Package Ownership、Spring 组装边界和 Architecture Test 保持一致**。
 
 ---
 
@@ -468,10 +468,10 @@ Plugin 不属于可信任的任意内部模块。
 
 ## 12. Build-time Boundary Enforcement
 
-建议至少采用两种机制之一：
+P0 使用单 Maven 工程，因此不能依赖构建子模块天然阻止非法依赖。边界检查至少采用：
 
-1. **Gradle subproject dependency isolation**；
-2. **ArchUnit / architecture test**。
+1. **Java Package Ownership 与公开 `api` package 约定**；
+2. **ArchUnit / architecture test，并接入 Maven `test` / `verify` 生命周期**。
 
 应自动检测：
 
@@ -479,9 +479,11 @@ Plugin 不属于可信任的任意内部模块。
 - `*.infrastructure.internal.*` 被跨模块引用；
 - Repository 跨 Owner 注入；
 - Domain 层依赖 Spring Web / DB Driver；
-- Plugin API 依赖 Server internal package。
+- Plugin API 依赖 Server internal package；
+- `*.api.*` 反向依赖 implementation package；
+- 业务模块反向依赖 Composition Root。
 
-推荐 CI 将 Boundary Violation 作为失败条件。
+推荐 CI 将 Boundary Violation 作为失败条件。单 Maven 编译成功不能替代 Architecture Boundary 验收。
 
 ---
 
@@ -521,7 +523,7 @@ run.ikaros.v2.resource.persistence
 
 若最终包名调整，不影响本设计原则。
 
-对外 contract 尽量放入独立 package，并使 implementation package 不作为其他模块编译依赖。
+对外 contract 尽量放入独立 package，并使 implementation package 不作为其他模块的合法依赖目标。
 
 ---
 

--- a/docs/00-product-baseline/P0-Implementation-Baseline.md
+++ b/docs/00-product-baseline/P0-Implementation-Baseline.md
@@ -2,8 +2,8 @@
 
 | 项目 | 内容 |
 |---|---|
-| 基线 ID | `v2-p0-foundation-0.2` |
-| 基线日期 | 2026-09-02 |
+| 基线 ID | `v2-p0-foundation-0.3` |
+| 基线日期 | 2026-09-06 |
 | 状态 | **已接受，可进入 Phase 0 工程基础实现** |
 | 目标 | 允许 V2 从设计阶段进入 Phase 0 工程基础实现 |
 | 非目标 | 不表示 Phase 1+ 的所有业务域已经冻结 |
@@ -18,7 +18,15 @@ Phase 1+ 领域实现 = 按各模块的 Definition of Ready 独立门禁
 发布就绪状态 = 尚未达到
 ```
 
-下一阶段的默认产出应转向模块骨架、Flyway、Application API、Outbox/Inbox、Background Task Runtime 与自动化测试，而不是继续横向增加 P0 设计文档。
+Phase 0 工程实施统一采用：
+
+```text
+Build = 根 pom.xml 单模块 Maven
+Migration = r2dbc-migrate + PostgreSQL R2DBC
+Module Boundary = Java Package Ownership + Spring Composition Boundary + Architecture Test
+```
+
+下一阶段的默认产出应转向模块骨架、`r2dbc-migrate`、Application API、Outbox/Inbox、Background Task Runtime 与自动化测试，而不是继续横向增加 P0 设计文档。
 
 ## 2. 规范性基线集合
 
@@ -48,6 +56,9 @@ Media Delivery / Restore 的独立 P0 Addendum 继续作为专项规范性扩展
 
 如果没有先修改设计文档或 ADR，Phase 0 实现不得自行改变：
 
+- 构建系统使用根 `pom.xml` 的单模块 Maven；P0 不切换 Gradle，也不以 Maven 多模块替代当前工程基线；
+- 逻辑模块边界通过 Java Package Ownership、显式 Spring Composition Boundary 与 Architecture Test 强制，不依赖构建子模块提供隔离；
+- 数据库 Schema Migration 使用 `r2dbc-migrate` + PostgreSQL R2DBC，不引入 Flyway/JDBC 第二数据库访问栈；
 - UUID 公开身份标识策略；
 - PostgreSQL Owner Schema 边界；
 - Resource / Attachment / Blob / Placement 的身份分离；
@@ -82,9 +93,9 @@ Media Delivery / Restore 的独立 P0 Addendum 继续作为专项规范性扩展
 建议按以下顺序推进：
 
 ```text
-模块骨架
+单 Maven 工程中的逻辑模块骨架
  -> 架构边界测试
- -> Flyway P0 基础 Schema
+ -> r2dbc-migrate P0 基础 Schema
  -> UUIDv7 / Clock / Problem / Principal
  -> Transaction + Outbox / Inbox
  -> Background Task Runtime

--- a/docs/00-product-baseline/Technical-Architecture-Design.md
+++ b/docs/00-product-baseline/Technical-Architecture-Design.md
@@ -4,8 +4,8 @@
 |---|---|
 | 文档名称 | Ikaros V2 技术架构设计 |
 | 适用版本 | Ikaros V2 |
-| 文档版本 | v0.1 |
-| 编写日期 | 2026-09-02 |
+| 文档版本 | v0.2 |
+| 编写日期 | 2026-09-06 |
 | 状态 | Engineering Baseline Draft |
 | 上位设计 | `System-Overview-Design.md`、`Database-Overview-Design.md`、`API-Convention-Design.md` |
 | 边界设计 | `Module-Package-Ownership-Design.md` |
@@ -13,7 +13,7 @@
 
 > 本文档定义 Ikaros V2 从“系统与领域设计”下降到 Java / Spring / Reactor / PostgreSQL 工程实现时必须遵守的技术架构。
 >
-> `System-Overview-Design.md` 回答系统由什么组成，`Module-Package-Ownership-Design.md` 回答谁拥有状态和代码，本文档进一步回答：**这些边界在进程、Gradle、Spring、线程、事务、数据库、事件、任务、缓存、网络、存储、可观测性和部署层面如何真正落地。**
+> `System-Overview-Design.md` 回答系统由什么组成，`Module-Package-Ownership-Design.md` 回答谁拥有状态和代码，本文档进一步回答：**这些边界在进程、Maven、Spring、线程、事务、数据库、事件、任务、缓存、网络、存储、可观测性和部署层面如何真正落地。**
 >
 > 本文档不重新定义业务领域模型。若本文与上位系统级设计发生冲突，以系统级设计为准；若实现需要改变本文中的 Foundation Rule，应先提交 ADR / 设计修改，再修改代码。
 
@@ -26,7 +26,7 @@ Ikaros V2 的工程实现不能只做到“代码能运行”，还必须让系�
 本文档重点解决以下问题：
 
 1. V2 的后端技术栈和进程模型是什么。
-2. 模块化单体如何在 Gradle 和 Spring Runtime 中形成真实边界。
+2. 模块化单体如何在单 Maven 工程的 Java Package 和 Spring Runtime 中形成真实、可验证的边界。
 3. HTTP / Realtime 请求如何进入 Application Command / Query。
 4. Domain、Application、Persistence、Infrastructure 的职责如何在代码中落地。
 5. WebFlux / Reactor 下哪些代码可以运行在 Event Loop，哪些必须隔离。
@@ -67,12 +67,12 @@ Ikaros V2 的默认工程架构冻结为：
 | Metrics | Micrometer / Actuator |
 | Trace Context | W3C Trace Context；支持 OpenTelemetry 接入 |
 | Test | JUnit 5 + Reactor Test + Testcontainers PostgreSQL + Architecture Test |
-| Build | Gradle Multi-Project |
+| Build | Maven Single Module（根 `pom.xml`） |
 | Deployment | Docker / Docker Compose first |
 
 说明：
 
-1. Patch Version 由 Gradle Platform / Version Catalog 管理，不应在所有设计文档重复绑定。
+1. Patch Version 由 Maven `dependencyManagement`、Spring Boot BOM 与集中 properties 管理，不应在所有设计文档重复绑定。
 2. V2 可以复用当前工程已经验证过的 Java 21、Spring Boot 4.x、WebFlux、R2DBC 技术经验，但 V1 的包结构、数据库表和历史实现不是 V2 兼容约束。
 3. Redis、独立 Search Engine、独立 Worker 都不是最小部署的强制依赖。
 4. 任何可选基础设施失效时，不得破坏 PostgreSQL 中业务真相的一致性。
@@ -159,49 +159,69 @@ Worker 不暴露普通业务 HTTP API，主要负责 Claim Background Task、长
 
 ---
 
-## 4. Gradle 工程拓扑
+## 4. Maven 单模块工程拓扑
 
 ### 4.1 原则
 
-V2 必须使用 Gradle Multi-Project 表达关键编译期边界。
+V2 P0 统一使用仓库根 `pom.xml` 的 **Maven Single Module** 构建，不切换 Gradle，也不以 Maven Multi-Module 作为当前工程基线。
 
-不要求每个最小包都拆成 Subproject，但以下边界应优先形成真实编译隔离：Platform Foundation、Integration / Event、Security、Background Task、P0 Core Domain API、P0 Core Domain Implementation、Server Composition Root、Plugin API / Runtime。
+模块化单体的边界不依赖构建子模块提供编译隔离，而通过以下机制共同强制：
+
+- Java Package Ownership；
+- `api / application / domain / adapter / persistence / config` 的逻辑分层；
+- 显式 Spring Module Configuration 与 Composition Root；
+- ArchUnit / Architecture Test；
+- Code Review 与 CI Gate。
+
+未来若单模块规模增长到确有必要引入物理构建模块，必须通过 ADR / 设计修改重新定义迁移收益与边界；不得在普通功能实现中顺手改变构建系统。
 
 ### 4.2 P0 推荐结构
 
+单 Maven 工程内推荐按逻辑 package 表达模块边界：
+
 ```text
 ikaros
-├── server
-├── platform
-│   ├── foundation
-│   ├── integration
-│   ├── security
-│   ├── task
-│   ├── operations
-│   ├── plugin-api
-│   └── plugin-runtime
-├── modules
-│   ├── resource
-│   │   ├── api
-│   │   └── impl
-│   ├── storage
-│   │   ├── api
-│   │   └── impl
-│   └── identity
-│       ├── api
-│       └── impl
-└── test-support
+├── pom.xml
+└── src/main/java/run/ikaros
+    ├── server
+    ├── platform
+    │   ├── foundation
+    │   ├── integration
+    │   ├── security
+    │   ├── task
+    │   ├── operations
+    │   ├── pluginapi
+    │   └── pluginruntime
+    └── modules
+        ├── resource
+        │   ├── api
+        │   ├── application
+        │   ├── domain
+        │   ├── adapter
+        │   └── persistence
+        ├── storage
+        │   ├── api
+        │   ├── application
+        │   ├── domain
+        │   ├── adapter
+        │   └── persistence
+        └── identity
+            ├── api
+            ├── application
+            ├── domain
+            ├── adapter
+            └── persistence
 ```
 
-后续领域可以按相同模式扩展。
+目录名是推荐布局，不是要求一次性重排现有源码的迁移任务；真正强制的是 Owner、依赖方向与自动化边界检查。
 
 ### 4.3 API / Implementation 分离
 
-`<module>:api` 只允许包含稳定跨模块契约，例如 Command / Query Contract、Capability Interface、Public Result DTO、Public Error、Permission Key、Event Contract Reference，以及真正属于公开契约的 ID / Value Object。
+`<module>.api` package 只允许包含稳定跨模块契约，例如 Command / Query Contract、Capability Interface、Public Result DTO、Public Error、Permission Key、Event Contract Reference，以及真正属于公开契约的 ID / Value Object。
 
-`<module>:api` 不应依赖 Spring WebFlux、R2DBC Driver、PostgreSQL Client、Redis Client、Storage SDK、ORM / Repository 或模块内部 Entity。
+`<module>.api` 不应依赖 Spring WebFlux、R2DBC Driver、PostgreSQL Client、Redis Client、Storage SDK、ORM / Repository 或模块内部 Entity。
 
-`<module>:impl` 负责 Application Handler、Domain Model、Persistence Adapter、Infrastructure Adapter、Web Adapter（若 endpoint 由领域拥有）以及 Module Spring Configuration。
+`<module>.application / domain / adapter / persistence / config` 属于模块实现，负责 Application Handler、Domain Model、Persistence Adapter、Infrastructure Adapter、Web Adapter（若 endpoint 由领域拥有）以及 Module Spring Configuration。
 
 ### 4.4 依赖方向
 
@@ -209,10 +229,10 @@ ikaros
 
 ```text
 server
-  -> module.impl
+  -> module implementation packages
   -> platform runtime
 
-moduleA.impl
+moduleA.application
   -> moduleA.api
   -> moduleB.api
   -> platform foundation/api
@@ -221,17 +241,17 @@ moduleA.impl
 禁止：
 
 ```text
-moduleA.impl -> moduleB.impl
-moduleA.impl -> moduleB.persistence
+moduleA implementation -> moduleB implementation
+moduleA -> moduleB.persistence
 moduleA.persistence -> moduleB.persistence
-moduleA -> server
+business module -> server
 platform.foundation -> business module
-api -> impl
+api -> implementation package
 ```
 
 ### 4.5 循环依赖
 
-任何 Gradle Project Circular Dependency 都是架构错误。
+任何跨逻辑模块的循环依赖都是架构错误，即使单 Maven 工程在编译期能够通过。
 
 出现业务双向依赖时，优先使用 Event、更小的 Capability Contract、Integration Module 中的稳定协调协议或重新划分所有权。禁止通过把两边代码搬进 `common` 解决循环依赖。
 
@@ -305,7 +325,7 @@ Adapter 不得把技术细节泄露给 Domain。
 
 ### 6.1 Server 是唯一 Composition Root
 
-只有 `server` 应负责启动完整 Spring ApplicationContext。
+单 Maven 工程中，`server` 仍作为逻辑 Composition Root；只有应用启动层应负责启动完整 Spring ApplicationContext。
 
 业务模块通过显式 Module Configuration 注册，例如：
 
@@ -578,13 +598,13 @@ Persistence Record / Entity 默认不直接等同于 Domain Aggregate。尤其�
 
 R2DBC 规范本身不包含数据库 Schema Migration 能力；Ikaros 使用独立的 **`r2dbc-migrate`** 组件在 R2DBC 之上完成版本化 SQL 迁移。
 
-V1 当前已经使用：
+当前工程使用：
 
 ```text
 name.nkonev.r2dbc-migrate:r2dbc-migrate-spring-boot-starter
 ```
 
-当前 V1 Gradle Platform 管理的版本为 `4.0.1`。V2 继续以该组件作为默认 Migration 基线，但具体 Patch Version 仍由 Gradle Platform / Version Catalog 集中管理，并在升级时验证 Spring Boot 4.x、R2DBC SPI 与 PostgreSQL Driver 的兼容性，本文档不长期冻结具体版本。
+当前根 `pom.xml` 通过 `r2dbc-migrate.version` 管理版本 `4.0.1`。V2 继续以该组件作为默认 Migration 基线，但具体 Patch Version 仍由 Maven `dependencyManagement` / properties / Spring Boot BOM 集中管理，并在升级时验证 Spring Boot 4.x、R2DBC SPI 与 PostgreSQL Driver 的兼容性，本文档不长期冻结具体版本。
 
 因此 V2 不再为了数据库迁移额外引入 Flyway + PostgreSQL JDBC Driver，也不建立“业务 R2DBC、迁移 JDBC”两套数据库访问栈。
 
@@ -604,16 +624,16 @@ Migration 和业务 Persistence 可以共享同一套 PostgreSQL 连接参数与
 
 ### 13.2 Migration Script Contract
 
-V1 已验证的脚本组织方式继续作为 V2 的默认起点：
+当前单 Maven 工程的默认脚本目录：
 
 ```text
-server/src/main/resources/db/migration/
+src/main/resources/db/migration/
 V<monotonic-version>__<description>.sql
 ```
 
-例如 V1 当前存在 `V202601101915__DDL_ATTACHMENT.sql` 这类版本化脚本。V2 可以继续采用相同的 `V...__...sql` 命名习惯，但这是 **Ikaros 的 Migration Script Contract**，不代表依赖 Flyway。
+现有工程中存在 `V202601101915__DDL_ATTACHMENT.sql` 这类版本化脚本。V2 可以继续采用相同的 `V...__...sql` 命名习惯，但这是 **Ikaros 的 Migration Script Contract**，不代表依赖 Flyway。
 
-P0 默认采用统一 Migration 目录和全局单调版本序列，避免不同 Gradle Module 各自产生相同版本号。文件名或描述必须能够识别 Owner Domain，例如：
+P0 默认采用统一 Migration 目录和全局单调版本序列，避免不同逻辑 Owner 各自产生相同版本号。文件名或描述必须能够识别 Owner Domain，例如：
 
 ```text
 V202609020001__PLATFORM_OUTBOX_BASELINE.sql
@@ -1128,14 +1148,14 @@ Reactive Pipeline 使用 Reactor `StepVerifier`。禁止测试通过到处 `.blo
 CI 必须执行 Architecture Boundary Test，至少验证：
 
 - `*.domain..` 不依赖 Spring Web / R2DBC；
-- module A 不依赖 module B impl；
+- module A 不依赖 module B implementation package；
 - 非 Owner Module 不依赖其他模块 persistence package；
 - Controller 不直接依赖 Repository；
 - Plugin 不依赖 Core Internal Package；
-- API Project 不依赖 Impl Project；
-- `server` 是 Composition Root，不被业务模块反向依赖。
+- API package 不依赖 implementation package；
+- `server` Composition Root 不被业务模块反向依赖。
 
-可以使用 ArchUnit + Gradle Dependency Verification 实现。
+单 Maven 工程默认使用 ArchUnit + Maven test/verify 生命周期实现这些边界检查；构建能通过不代表逻辑模块依赖合法。
 
 ### 28.6 Contract Test
 
@@ -1163,11 +1183,11 @@ compile
 
 ### 29.2 Dependency Management
 
-第三方版本通过 Gradle Version Catalog 或 Java Platform / BOM 集中管理。禁止多个模块独立定义同一个核心依赖的不同版本。
+第三方版本通过 Maven `dependencyManagement`、Spring Boot BOM 与集中 properties 管理。禁止在不同逻辑模块中各自定义同一个核心依赖的不同版本。
 
 ### 29.3 Reproducible Build
 
-Release Build 必须锁定 JDK Major、Gradle Wrapper、Node / pnpm（若构建 Console），生成 build metadata，输出版本与 git commit，并让容器镜像可追踪到 commit。
+Release Build 必须锁定 JDK Major、Maven Wrapper / Maven 版本、Node / pnpm（若构建 Console），生成 build metadata，输出版本与 git commit，并让容器镜像可追踪到 commit。
 
 ---
 
@@ -1240,42 +1260,42 @@ Worker 不能因为执行 FFmpeg 就拥有 Media Domain Schema。
 
 ## 33. P0 代码骨架建议
 
-Phase 0 的首批代码可以按以下顺序落地：
+Phase 0 的首批代码可以在单 Maven 工程内按以下逻辑 package 顺序落地：
 
 ```text
-1. platform:foundation
+1. platform.foundation
    - UUIDv7
    - Clock
    - Timezone
    - ExecutionContext
    - Error primitive
 
-2. platform:integration
+2. platform.integration
    - EventEnvelope
    - OutboxRepository
    - InboxRepository
    - Dispatcher
    - ConsumerRegistry
 
-3. platform:security
+3. platform.security
    - Principal
    - PermissionRegistry
    - AuthorizationService
 
-4. platform:task
+4. platform.task
    - Task model
    - Attempt model
    - Claim / Lease
    - TaskHandlerRegistry
    - WorkerLoop
 
-5. modules:resource
+5. resource
    - api
-   - impl/application/domain/persistence
+   - application/domain/persistence
 
-6. modules:storage
+6. storage
    - api
-   - impl/application/domain/persistence
+   - application/domain/persistence
    - filesystem adapter
 
 7. server
@@ -1382,10 +1402,10 @@ P0 实现合并前至少具备以下自动化检查：
 | Gate | 必须验证 |
 |---|---|
 | `ARCH-001` | Domain 不依赖 Web / DB / Redis / Storage SDK |
-| `ARCH-002` | Module Impl 不依赖其他 Module Impl |
+| `ARCH-002` | Module Implementation 不依赖其他 Module Implementation |
 | `ARCH-003` | Controller 不直接依赖 Repository |
 | `ARCH-004` | 非 Owner 不访问其他模块 Persistence Package |
-| `ARCH-005` | API Project 不依赖 Impl Project |
+| `ARCH-005` | API Package 不依赖 Implementation Package |
 | `ARCH-006` | Server 是 Composition Root |
 | `REACT-001` | 关键 Runtime Package 无 `.block*()` |
 | `DB-001` | `r2dbc-migrate` 可在空 PostgreSQL 完整升级 |
@@ -1405,6 +1425,7 @@ P0 实现合并前至少具备以下自动化检查：
 
 以下变化必须新增或修改 ADR，不能直接在实现中发生：
 
+- 从 Maven Single Module 切换到 Gradle、Maven Multi-Module 或其他构建拓扑；
 - 从 Modular Monolith 拆成 Microservice；
 - 引入第二个业务关系数据库；
 - 放弃 R2DBC 改用 JPA/JDBC 主栈；
@@ -1425,7 +1446,7 @@ P0 实现合并前至少具备以下自动化检查：
 
 一个 P0 模块不能只因为“Controller 能返回 200”就视为完成。
 
-技术架构层 DoD 至少要求：Gradle Ownership 清晰；Package Boundary 通过 Architecture Test；Domain 不依赖 Infrastructure；Command / Query 契约已实现；Permission 在 Application Boundary 生效；PostgreSQL Schema / Constraint 已通过 Testcontainers；Reactive Transaction 正确；Durable Event 进入 Outbox；Consumer 支持 Inbox 幂等；长任务进入 Background Task；HTTP 与 OpenAPI 一致；Error 使用统一 Problem Contract；Metrics / Trace / Correlation 可观测；无不受控 Blocking Call；无跨 Owner Repository / SQL；Cache / Search 关闭后核心业务仍正确；Crash / Retry / Duplicate Delivery 有自动化测试。
+技术架构层 DoD 至少要求：Maven 单模块工程基线明确且 Package Ownership 清晰；Package Boundary 通过 Architecture Test；Domain 不依赖 Infrastructure；Command / Query 契约已实现；Permission 在 Application Boundary 生效；PostgreSQL Schema / Constraint 已通过 Testcontainers；Reactive Transaction 正确；Durable Event 进入 Outbox；Consumer 支持 Inbox 幂等；长任务进入 Background Task；HTTP 与 OpenAPI 一致；Error 使用统一 Problem Contract；Metrics / Trace / Correlation 可观测；无不受控 Blocking Call；无跨 Owner Repository / SQL；Cache / Search 关闭后核心业务仍正确；Crash / Retry / Duplicate Delivery 有自动化测试。
 
 ---
 

--- a/docs/00-product-baseline/V2-Document-Index.md
+++ b/docs/00-product-baseline/V2-Document-Index.md
@@ -325,7 +325,7 @@ Personal Drive 的产品、系统、服务端、App / CMS 交互，以及根导�
 3. 将领域不变量映射为 PostgreSQL Constraint / Transaction Boundary；
 4. 将 Command / Query / Event 映射为 API 与内部接口；
 5. 为跨域事件建立契约版本与 Outbox / Consumer 幂等策略；
-6. 为每个子系统生成首批 Flyway Schema 设计；
+6. 为每个子系统生成首批 `r2dbc-migrate` Schema / Migration 设计；
 7. 建立 V2 implementation roadmap 与依赖图；
 8. 只有当某个实现问题超出现有设计边界时，再新增专项设计。
 

--- a/docs/00-product-baseline/database/P0-Database-Schema-Design.md
+++ b/docs/00-product-baseline/database/P0-Database-Schema-Design.md
@@ -11,7 +11,7 @@
 | 数据库基线 | `../Database-Overview-Design.md` |
 | 模块边界基线 | `../Module-Package-Ownership-Design.md` |
 
-> 本文档把 V2 已经确定的数据库原则向下收敛为首批可以直接映射到 Flyway Migration、Repository 与 Integration Test 的 P0 Schema Contract。
+> 本文档把 V2 已经确定的数据库原则向下收敛为首批可以直接映射到 `r2dbc-migrate` Migration、Repository 与 Integration Test 的 P0 Schema Contract。
 >
 > 本文档开始锁定 P0 的物理 Schema、Table、Column、Constraint 与关键 Index 名称。实现若需要偏离本文档，必须先修改本文档或通过明确 ADR 记录偏离原因，不能由 Repository 实现静默产生另一套数据库事实。
 >
@@ -938,22 +938,22 @@ Lease/Heartbeat 更新必须是短事务。
 
 # Part G — Migration Plan
 
-## 28. 首批 Flyway 顺序
+## 28. 首批 `r2dbc-migrate` 顺序
 
-建议将首批 Migration 分为以下可独立审查步骤：
+建议将首批 Migration 分为以下可独立审查步骤，并使用仓库统一的 `V<monotonic-version>__<description>.sql` 命名契约：
 
 ```text
-V2_0001__create_schemas.sql
-V2_0002__identity_foundation.sql
-V2_0003__integration_outbox_inbox.sql
-V2_0004__operations_background_task.sql
-V2_0005__resource_core.sql
-V2_0006__storage_core.sql
-V2_0007__seed_permission_registry.sql
-V2_0008__seed_builtin_roles.sql
+V<...001>__CREATE_SCHEMAS.sql
+V<...002>__IDENTITY_FOUNDATION.sql
+V<...003>__INTEGRATION_OUTBOX_INBOX.sql
+V<...004>__OPERATIONS_BACKGROUND_TASK.sql
+V<...005>__RESOURCE_CORE.sql
+V<...006>__STORAGE_CORE.sql
+V<...007>__SEED_PERMISSION_REGISTRY.sql
+V<...008>__SEED_BUILTIN_ROLES.sql
 ```
 
-版本号命名可根据项目最终 Flyway Version Policy 调整，但顺序依赖不得倒置。
+具体单调版本号由提交时按仓库 Migration Version Policy 分配，但顺序依赖不得倒置。
 
 `identity_foundation` 不创建登录 Session 表；Identity 持久化基线只保留账号、权限、角色、绑定、凭据/验证所需数据以及用户级 `security_version`。
 
@@ -1021,9 +1021,9 @@ P0 至少将以下不变量下降到 Constraint：
 
 # Part I — P0 Schema Exit Criteria
 
-## 31. Definition of Ready for Flyway
+## 31. Definition of Ready for `r2dbc-migrate`
 
-该 Schema Contract 进入真实 Flyway 实现前必须满足：
+该 Schema Contract 进入真实 `r2dbc-migrate` 实现前必须满足：
 
 - [ ] 所有表有明确 Owner Module。
 - [ ] 每个跨域 UUID 已声明是否建立 FK。
@@ -1038,7 +1038,7 @@ P0 至少将以下不变量下降到 Constraint：
 
 只有以下全部成立才视为首批 P0 Schema 完成：
 
-- [ ] Flyway 可以从空 PostgreSQL 创建全部 P0 Schema。
+- [ ] `r2dbc-migrate` 可以从空 PostgreSQL 创建全部 P0 Schema。
 - [ ] Migration 可在 CI 重复从零验证。
 - [ ] Constraint Integration Test 覆盖本文档第 30 节全部 DB-enforced invariant。
 - [ ] Repository Boundary Test 能阻止模块直接访问非 Owner Schema。

--- a/docs/90-diagrams/v2-Technical-Architecture-Design.md
+++ b/docs/90-diagrams/v2-Technical-Architecture-Design.md
@@ -4,8 +4,8 @@
 |---|---|
 | 文档名称 | Ikaros V2 技术架构设计 |
 | 适用版本 | Ikaros V2 |
-| 文档版本 | v0.1 |
-| 编写日期 | 2026-09-02 |
+| 文档版本 | v0.2 |
+| 编写日期 | 2026-09-06 |
 | 状态 | Engineering Baseline Draft |
 | 上位设计 | `System-Overview-Design.md`、`Database-Overview-Design.md`、`API-Convention-Design.md` |
 | 边界设计 | `Module-Package-Ownership-Design.md` |
@@ -13,7 +13,7 @@
 
 > 本文档定义 Ikaros V2 从“系统与领域设计”下降到 Java / Spring / Reactor / PostgreSQL 工程实现时必须遵守的技术架构。
 >
-> `System-Overview-Design.md` 回答系统由什么组成，`Module-Package-Ownership-Design.md` 回答谁拥有状态和代码，本文档进一步回答：**这些边界在进程、Gradle、Spring、线程、事务、数据库、事件、任务、缓存、网络、存储、可观测性和部署层面如何真正落地。**
+> `System-Overview-Design.md` 回答系统由什么组成，`Module-Package-Ownership-Design.md` 回答谁拥有状态和代码，本文档进一步回答：**这些边界在进程、Maven、Spring、线程、事务、数据库、事件、任务、缓存、网络、存储、可观测性和部署层面如何真正落地。**
 >
 > 本文档不重新定义业务领域模型。若本文与上位系统级设计发生冲突，以系统级设计为准；若实现需要改变本文中的 Foundation Rule，应先提交 ADR / 设计修改，再修改代码。
 
@@ -26,7 +26,7 @@ Ikaros V2 的工程实现不能只做到“代码能运行”，还必须让系�
 本文档重点解决以下问题：
 
 1. V2 的后端技术栈和进程模型是什么。
-2. 模块化单体如何在 Gradle 和 Spring Runtime 中形成真实边界。
+2. 模块化单体如何在单 Maven 工程的 Java Package 和 Spring Runtime 中形成真实、可验证的边界。
 3. HTTP / Realtime 请求如何进入 Application Command / Query。
 4. Domain、Application、Persistence、Infrastructure 的职责如何在代码中落地。
 5. WebFlux / Reactor 下哪些代码可以运行在 Event Loop，哪些必须隔离。
@@ -67,12 +67,12 @@ Ikaros V2 的默认工程架构冻结为：
 | Metrics | Micrometer / Actuator |
 | Trace Context | W3C Trace Context；支持 OpenTelemetry 接入 |
 | Test | JUnit 5 + Reactor Test + Testcontainers PostgreSQL + Architecture Test |
-| Build | Gradle Multi-Project |
+| Build | Maven Single Module（根 `pom.xml`） |
 | Deployment | Docker / Docker Compose first |
 
 说明：
 
-1. Patch Version 由 Gradle Platform / Version Catalog 管理，不应在所有设计文档重复绑定。
+1. Patch Version 由 Maven `dependencyManagement`、Spring Boot BOM 与集中 properties 管理，不应在所有设计文档重复绑定。
 2. V2 可以复用当前工程已经验证过的 Java 21、Spring Boot 4.x、WebFlux、R2DBC 技术经验，但 V1 的包结构、数据库表和历史实现不是 V2 兼容约束。
 3. Redis、独立 Search Engine、独立 Worker 都不是最小部署的强制依赖。
 4. 任何可选基础设施失效时，不得破坏 PostgreSQL 中业务真相的一致性。
@@ -159,49 +159,69 @@ Worker 不暴露普通业务 HTTP API，主要负责 Claim Background Task、长
 
 ---
 
-## 4. Gradle 工程拓扑
+## 4. Maven 单模块工程拓扑
 
 ### 4.1 原则
 
-V2 必须使用 Gradle Multi-Project 表达关键编译期边界。
+V2 P0 统一使用仓库根 `pom.xml` 的 **Maven Single Module** 构建，不切换 Gradle，也不以 Maven Multi-Module 作为当前工程基线。
 
-不要求每个最小包都拆成 Subproject，但以下边界应优先形成真实编译隔离：Platform Foundation、Integration / Event、Security、Background Task、P0 Core Domain API、P0 Core Domain Implementation、Server Composition Root、Plugin API / Runtime。
+模块化单体的边界不依赖构建子模块提供编译隔离，而通过以下机制共同强制：
+
+- Java Package Ownership；
+- `api / application / domain / adapter / persistence / config` 的逻辑分层；
+- 显式 Spring Module Configuration 与 Composition Root；
+- ArchUnit / Architecture Test；
+- Code Review 与 CI Gate。
+
+未来若单模块规模增长到确有必要引入物理构建模块，必须通过 ADR / 设计修改重新定义迁移收益与边界；不得在普通功能实现中顺手改变构建系统。
 
 ### 4.2 P0 推荐结构
 
+单 Maven 工程内推荐按逻辑 package 表达模块边界：
+
 ```text
 ikaros
-├── server
-├── platform
-│   ├── foundation
-│   ├── integration
-│   ├── security
-│   ├── task
-│   ├── operations
-│   ├── plugin-api
-│   └── plugin-runtime
-├── modules
-│   ├── resource
-│   │   ├── api
-│   │   └── impl
-│   ├── storage
-│   │   ├── api
-│   │   └── impl
-│   └── identity
-│       ├── api
-│       └── impl
-└── test-support
+├── pom.xml
+└── src/main/java/run/ikaros
+    ├── server
+    ├── platform
+    │   ├── foundation
+    │   ├── integration
+    │   ├── security
+    │   ├── task
+    │   ├── operations
+    │   ├── pluginapi
+    │   └── pluginruntime
+    └── modules
+        ├── resource
+        │   ├── api
+        │   ├── application
+        │   ├── domain
+        │   ├── adapter
+        │   └── persistence
+        ├── storage
+        │   ├── api
+        │   ├── application
+        │   ├── domain
+        │   ├── adapter
+        │   └── persistence
+        └── identity
+            ├── api
+            ├── application
+            ├── domain
+            ├── adapter
+            └── persistence
 ```
 
-后续领域可以按相同模式扩展。
+目录名是推荐布局，不是要求一次性重排现有源码的迁移任务；真正强制的是 Owner、依赖方向与自动化边界检查。
 
 ### 4.3 API / Implementation 分离
 
-`<module>:api` 只允许包含稳定跨模块契约，例如 Command / Query Contract、Capability Interface、Public Result DTO、Public Error、Permission Key、Event Contract Reference，以及真正属于公开契约的 ID / Value Object。
+`<module>.api` package 只允许包含稳定跨模块契约，例如 Command / Query Contract、Capability Interface、Public Result DTO、Public Error、Permission Key、Event Contract Reference，以及真正属于公开契约的 ID / Value Object。
 
-`<module>:api` 不应依赖 Spring WebFlux、R2DBC Driver、PostgreSQL Client、Redis Client、Storage SDK、ORM / Repository 或模块内部 Entity。
+`<module>.api` 不应依赖 Spring WebFlux、R2DBC Driver、PostgreSQL Client、Redis Client、Storage SDK、ORM / Repository 或模块内部 Entity。
 
-`<module>:impl` 负责 Application Handler、Domain Model、Persistence Adapter、Infrastructure Adapter、Web Adapter（若 endpoint 由领域拥有）以及 Module Spring Configuration。
+`<module>.application / domain / adapter / persistence / config` 属于模块实现，负责 Application Handler、Domain Model、Persistence Adapter、Infrastructure Adapter、Web Adapter（若 endpoint 由领域拥有）以及 Module Spring Configuration。
 
 ### 4.4 依赖方向
 
@@ -209,10 +229,10 @@ ikaros
 
 ```text
 server
-  -> module.impl
+  -> module implementation packages
   -> platform runtime
 
-moduleA.impl
+moduleA.application
   -> moduleA.api
   -> moduleB.api
   -> platform foundation/api
@@ -221,17 +241,17 @@ moduleA.impl
 禁止：
 
 ```text
-moduleA.impl -> moduleB.impl
-moduleA.impl -> moduleB.persistence
+moduleA implementation -> moduleB implementation
+moduleA -> moduleB.persistence
 moduleA.persistence -> moduleB.persistence
-moduleA -> server
+business module -> server
 platform.foundation -> business module
-api -> impl
+api -> implementation package
 ```
 
 ### 4.5 循环依赖
 
-任何 Gradle Project Circular Dependency 都是架构错误。
+任何跨逻辑模块的循环依赖都是架构错误，即使单 Maven 工程在编译期能够通过。
 
 出现业务双向依赖时，优先使用 Event、更小的 Capability Contract、Integration Module 中的稳定协调协议或重新划分所有权。禁止通过把两边代码搬进 `common` 解决循环依赖。
 
@@ -305,7 +325,7 @@ Adapter 不得把技术细节泄露给 Domain。
 
 ### 6.1 Server 是唯一 Composition Root
 
-只有 `server` 应负责启动完整 Spring ApplicationContext。
+单 Maven 工程中，`server` 仍作为逻辑 Composition Root；只有应用启动层应负责启动完整 Spring ApplicationContext。
 
 业务模块通过显式 Module Configuration 注册，例如：
 
@@ -578,13 +598,13 @@ Persistence Record / Entity 默认不直接等同于 Domain Aggregate。尤其�
 
 R2DBC 规范本身不包含数据库 Schema Migration 能力；Ikaros 使用独立的 **`r2dbc-migrate`** 组件在 R2DBC 之上完成版本化 SQL 迁移。
 
-V1 当前已经使用：
+当前工程使用：
 
 ```text
 name.nkonev.r2dbc-migrate:r2dbc-migrate-spring-boot-starter
 ```
 
-当前 V1 Gradle Platform 管理的版本为 `4.0.1`。V2 继续以该组件作为默认 Migration 基线，但具体 Patch Version 仍由 Gradle Platform / Version Catalog 集中管理，并在升级时验证 Spring Boot 4.x、R2DBC SPI 与 PostgreSQL Driver 的兼容性，本文档不长期冻结具体版本。
+当前根 `pom.xml` 通过 `r2dbc-migrate.version` 管理版本 `4.0.1`。V2 继续以该组件作为默认 Migration 基线，但具体 Patch Version 仍由 Maven `dependencyManagement` / properties / Spring Boot BOM 集中管理，并在升级时验证 Spring Boot 4.x、R2DBC SPI 与 PostgreSQL Driver 的兼容性，本文档不长期冻结具体版本。
 
 因此 V2 不再为了数据库迁移额外引入 Flyway + PostgreSQL JDBC Driver，也不建立“业务 R2DBC、迁移 JDBC”两套数据库访问栈。
 
@@ -604,16 +624,16 @@ Migration 和业务 Persistence 可以共享同一套 PostgreSQL 连接参数与
 
 ### 13.2 Migration Script Contract
 
-V1 已验证的脚本组织方式继续作为 V2 的默认起点：
+当前单 Maven 工程的默认脚本目录：
 
 ```text
-server/src/main/resources/db/migration/
+src/main/resources/db/migration/
 V<monotonic-version>__<description>.sql
 ```
 
-例如 V1 当前存在 `V202601101915__DDL_ATTACHMENT.sql` 这类版本化脚本。V2 可以继续采用相同的 `V...__...sql` 命名习惯，但这是 **Ikaros 的 Migration Script Contract**，不代表依赖 Flyway。
+现有工程中存在 `V202601101915__DDL_ATTACHMENT.sql` 这类版本化脚本。V2 可以继续采用相同的 `V...__...sql` 命名习惯，但这是 **Ikaros 的 Migration Script Contract**，不代表依赖 Flyway。
 
-P0 默认采用统一 Migration 目录和全局单调版本序列，避免不同 Gradle Module 各自产生相同版本号。文件名或描述必须能够识别 Owner Domain，例如：
+P0 默认采用统一 Migration 目录和全局单调版本序列，避免不同逻辑 Owner 各自产生相同版本号。文件名或描述必须能够识别 Owner Domain，例如：
 
 ```text
 V202609020001__PLATFORM_OUTBOX_BASELINE.sql
@@ -1128,14 +1148,14 @@ Reactive Pipeline 使用 Reactor `StepVerifier`。禁止测试通过到处 `.blo
 CI 必须执行 Architecture Boundary Test，至少验证：
 
 - `*.domain..` 不依赖 Spring Web / R2DBC；
-- module A 不依赖 module B impl；
+- module A 不依赖 module B implementation package；
 - 非 Owner Module 不依赖其他模块 persistence package；
 - Controller 不直接依赖 Repository；
 - Plugin 不依赖 Core Internal Package；
-- API Project 不依赖 Impl Project；
-- `server` 是 Composition Root，不被业务模块反向依赖。
+- API package 不依赖 implementation package；
+- `server` Composition Root 不被业务模块反向依赖。
 
-可以使用 ArchUnit + Gradle Dependency Verification 实现。
+单 Maven 工程默认使用 ArchUnit + Maven test/verify 生命周期实现这些边界检查；构建能通过不代表逻辑模块依赖合法。
 
 ### 28.6 Contract Test
 
@@ -1163,11 +1183,11 @@ compile
 
 ### 29.2 Dependency Management
 
-第三方版本通过 Gradle Version Catalog 或 Java Platform / BOM 集中管理。禁止多个模块独立定义同一个核心依赖的不同版本。
+第三方版本通过 Maven `dependencyManagement`、Spring Boot BOM 与集中 properties 管理。禁止在不同逻辑模块中各自定义同一个核心依赖的不同版本。
 
 ### 29.3 Reproducible Build
 
-Release Build 必须锁定 JDK Major、Gradle Wrapper、Node / pnpm（若构建 Console），生成 build metadata，输出版本与 git commit，并让容器镜像可追踪到 commit。
+Release Build 必须锁定 JDK Major、Maven Wrapper / Maven 版本、Node / pnpm（若构建 Console），生成 build metadata，输出版本与 git commit，并让容器镜像可追踪到 commit。
 
 ---
 
@@ -1240,42 +1260,42 @@ Worker 不能因为执行 FFmpeg 就拥有 Media Domain Schema。
 
 ## 33. P0 代码骨架建议
 
-Phase 0 的首批代码可以按以下顺序落地：
+Phase 0 的首批代码可以在单 Maven 工程内按以下逻辑 package 顺序落地：
 
 ```text
-1. platform:foundation
+1. platform.foundation
    - UUIDv7
    - Clock
    - Timezone
    - ExecutionContext
    - Error primitive
 
-2. platform:integration
+2. platform.integration
    - EventEnvelope
    - OutboxRepository
    - InboxRepository
    - Dispatcher
    - ConsumerRegistry
 
-3. platform:security
+3. platform.security
    - Principal
    - PermissionRegistry
    - AuthorizationService
 
-4. platform:task
+4. platform.task
    - Task model
    - Attempt model
    - Claim / Lease
    - TaskHandlerRegistry
    - WorkerLoop
 
-5. modules:resource
+5. resource
    - api
-   - impl/application/domain/persistence
+   - application/domain/persistence
 
-6. modules:storage
+6. storage
    - api
-   - impl/application/domain/persistence
+   - application/domain/persistence
    - filesystem adapter
 
 7. server
@@ -1382,10 +1402,10 @@ P0 实现合并前至少具备以下自动化检查：
 | Gate | 必须验证 |
 |---|---|
 | `ARCH-001` | Domain 不依赖 Web / DB / Redis / Storage SDK |
-| `ARCH-002` | Module Impl 不依赖其他 Module Impl |
+| `ARCH-002` | Module Implementation 不依赖其他 Module Implementation |
 | `ARCH-003` | Controller 不直接依赖 Repository |
 | `ARCH-004` | 非 Owner 不访问其他模块 Persistence Package |
-| `ARCH-005` | API Project 不依赖 Impl Project |
+| `ARCH-005` | API Package 不依赖 Implementation Package |
 | `ARCH-006` | Server 是 Composition Root |
 | `REACT-001` | 关键 Runtime Package 无 `.block*()` |
 | `DB-001` | `r2dbc-migrate` 可在空 PostgreSQL 完整升级 |
@@ -1405,6 +1425,7 @@ P0 实现合并前至少具备以下自动化检查：
 
 以下变化必须新增或修改 ADR，不能直接在实现中发生：
 
+- 从 Maven Single Module 切换到 Gradle、Maven Multi-Module 或其他构建拓扑；
 - 从 Modular Monolith 拆成 Microservice；
 - 引入第二个业务关系数据库；
 - 放弃 R2DBC 改用 JPA/JDBC 主栈；
@@ -1425,7 +1446,7 @@ P0 实现合并前至少具备以下自动化检查：
 
 一个 P0 模块不能只因为“Controller 能返回 200”就视为完成。
 
-技术架构层 DoD 至少要求：Gradle Ownership 清晰；Package Boundary 通过 Architecture Test；Domain 不依赖 Infrastructure；Command / Query 契约已实现；Permission 在 Application Boundary 生效；PostgreSQL Schema / Constraint 已通过 Testcontainers；Reactive Transaction 正确；Durable Event 进入 Outbox；Consumer 支持 Inbox 幂等；长任务进入 Background Task；HTTP 与 OpenAPI 一致；Error 使用统一 Problem Contract；Metrics / Trace / Correlation 可观测；无不受控 Blocking Call；无跨 Owner Repository / SQL；Cache / Search 关闭后核心业务仍正确；Crash / Retry / Duplicate Delivery 有自动化测试。
+技术架构层 DoD 至少要求：Maven 单模块工程基线明确且 Package Ownership 清晰；Package Boundary 通过 Architecture Test；Domain 不依赖 Infrastructure；Command / Query 契约已实现；Permission 在 Application Boundary 生效；PostgreSQL Schema / Constraint 已通过 Testcontainers；Reactive Transaction 正确；Durable Event 进入 Outbox；Consumer 支持 Inbox 幂等；长任务进入 Background Task；HTTP 与 OpenAPI 一致；Error 使用统一 Problem Contract；Metrics / Trace / Correlation 可观测；无不受控 Blocking Call；无跨 Owner Repository / SQL；Cache / Search 关闭后核心业务仍正确；Crash / Retry / Duplicate Delivery 有自动化测试。
 
 ---
 


### PR DESCRIPTION
## 背景

对应 #904，当前工程实现与部分 V2 设计文档存在两类明确差异：

1. 当前仓库已经使用根 `pom.xml` 的单模块 Maven 构建，但部分设计仍要求 Gradle Multi-Project / Gradle subproject 隔离；
2. 当前工程已经使用 `r2dbc-migrate` + PostgreSQL R2DBC，但部分 P0 文档仍正向要求 Flyway。

本 PR 以**当前已确认工程决议**为准修正文档，不进行构建系统迁移，也不引入第二套数据库访问栈。

## 决议

```text
Build = 根 pom.xml 单模块 Maven
Migration = r2dbc-migrate + PostgreSQL R2DBC
Module Boundary = Java Package Ownership + Spring Composition Boundary + Architecture Test
```

- P0 不切换 Gradle，也不改成 Maven Multi-Module；
- 逻辑模块隔离由 Java Package Ownership、公开 API package、显式 Spring Module Configuration / Composition Root、ArchUnit / Architecture Test 强制；
- Schema Migration 统一使用 `r2dbc-migrate`，不引入 Flyway + JDBC 第二访问栈；
- 如果未来需要改变构建拓扑，必须单独通过 ADR / 设计修改决策。

## 变更

- 更新 `Technical-Architecture-Design.md`：Build Foundation Rule 改为 Maven Single Module，并同步 Maven 依赖管理、模块边界、CI、Migration 目录与 ADR 条件；
- 同步 `docs/90-diagrams/v2-Technical-Architecture-Design.md` 镜像；
- 更新 `P0-Implementation-Baseline.md`，冻结 Maven / r2dbc-migrate / Package Boundary 决议；
- 更新 `Module-Package-Ownership-Design.md`，移除 Gradle subproject 作为 P0 边界前提；
- 更新 `Engineering-Implementation-Index.md` 与 `V2-Document-Index.md`；
- 更新 `database/P0-Database-Schema-Design.md`，将正向 Flyway 实施要求统一为 `r2dbc-migrate`。

历史 `CHANGELOG` 中的 Gradle / Flyway 记录不修改；“禁止重新引入 JDBC/Flyway 第二访问栈”之类的约束说明继续保留。

## 验收依据

当前工程事实：

- 根 `pom.xml` 为单一 `run.ikaros:ikaros` Maven artifact；
- Java 21 / Spring Boot 4.x / WebFlux / R2DBC 已由当前 Maven 工程声明；
- `pom.xml` 已使用 `r2dbc-migrate-spring-boot-starter`；
- `application.yaml` 的 migration path 为 `classpath:/db/migration`；
- 本 PR 仅修改文档，没有修改 `pom.xml`、应用代码或构建系统。

成功判定：规范性 V2 文档与上述工程事实一致，P0 后续实现不再被要求切换 Gradle 或使用 Flyway。

失败判定：若后续实现尝试通过普通功能 PR 切换构建拓扑，或引入 Flyway/JDBC 第二数据库访问栈，应由基线/ADR 门禁阻止；逻辑模块越界应由 Architecture Test 阻止。

Closes #904