### PR TITLE
修复：完成 A01 API、PostgreSQL 与 Console 联调

### DIFF
--- a/application/src/main/java/run/ikaros/application/IkarosApplication.java
+++ b/application/src/main/java/run/ikaros/application/IkarosApplication.java
@@ -12,7 +12,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableR2dbcRepositories(basePackages = {
     "run.ikaros.activity",
     "run.ikaros.authentication",
-    "run.ikaros.authentication.verification",
     "run.ikaros.authorization",
     "run.ikaros.backup",
     "run.ikaros.collection",
@@ -27,8 +26,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
     "run.ikaros.music",
     "run.ikaros.notes",
     "run.ikaros.offline",
-    "run.ikaros.operations.audit",
-    "run.ikaros.operations.task",
+    "run.ikaros.operations",
     "run.ikaros.password",
     "run.ikaros.photo",
     "run.ikaros.planning",

--- a/application/src/main/java/run/ikaros/application/IkarosApplication.java
+++ b/application/src/main/java/run/ikaros/application/IkarosApplication.java
@@ -2,12 +2,46 @@ package run.ikaros.application;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Ikaros 应用启动入口，承载全部模块化单体能力。
  */
 @SpringBootApplication(scanBasePackages = "run.ikaros")
+@EnableR2dbcRepositories(basePackages = {
+    "run.ikaros.activity",
+    "run.ikaros.authentication",
+    "run.ikaros.authentication.verification",
+    "run.ikaros.authorization",
+    "run.ikaros.backup",
+    "run.ikaros.collection",
+    "run.ikaros.document",
+    "run.ikaros.drive",
+    "run.ikaros.event",
+    "run.ikaros.finance",
+    "run.ikaros.game",
+    "run.ikaros.ingestion",
+    "run.ikaros.media",
+    "run.ikaros.metadata",
+    "run.ikaros.music",
+    "run.ikaros.notes",
+    "run.ikaros.offline",
+    "run.ikaros.operations.audit",
+    "run.ikaros.operations.task",
+    "run.ikaros.password",
+    "run.ikaros.photo",
+    "run.ikaros.planning",
+    "run.ikaros.plugin",
+    "run.ikaros.progress",
+    "run.ikaros.reading",
+    "run.ikaros.relation",
+    "run.ikaros.resource",
+    "run.ikaros.search",
+    "run.ikaros.sharing",
+    "run.ikaros.storage",
+    "run.ikaros.sync"
+})
 @EnableScheduling
 public class IkarosApplication {
 

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -11,7 +11,7 @@ spring:
 
 r2dbc:
   migrate:
-    resources-paths: classpath*:/db/migration
+    resources-paths: classpath*:/db/migration/*.sql
 
 springdoc:
   api-docs:

--- a/integration/src/main/java/run/ikaros/event/DurableEventService.java
+++ b/integration/src/main/java/run/ikaros/event/DurableEventService.java
@@ -69,7 +69,8 @@ public class DurableEventService implements DurableEventPublisher {
 
     private Mono<OutboxEventEntity> appendNow(String eventType, int schemaVersion, String producerSubsystem,
                                               String subjectType, UUID subjectId, String payloadJson, PrincipalContext context) {
-        return outbox.save(new OutboxEventEntity(null, eventType, schemaVersion, producerSubsystem, subjectType, subjectId,
+        return outbox.save(new OutboxEventEntity(null, eventType, schemaVersion, subjectType, subjectId,
+            producerSubsystem, subjectType, subjectId,
             payloadJson, Instant.now(), 0, null, null,
             context == null ? null : context.requestId(),
             context == null ? null : context.correlationId(),

--- a/integration/src/main/java/run/ikaros/event/OutboxEventEntity.java
+++ b/integration/src/main/java/run/ikaros/event/OutboxEventEntity.java
@@ -12,6 +12,8 @@ public record OutboxEventEntity(
     @Id UUID id,
     @Column("event_type") String eventType,
     @Column("schema_version") int schemaVersion,
+    @Column("aggregate_type") String aggregateType,
+    @Column("aggregate_id") UUID aggregateId,
     @Column("producer_subsystem") String producerSubsystem,
     @Column("subject_type") String subjectType,
     @Column("subject_id") UUID subjectId,
@@ -28,7 +30,8 @@ public record OutboxEventEntity(
     public OutboxEventEntity(UUID id, String eventType, int schemaVersion, String aggregateType, UUID aggregateId,
                              String payloadJson, Instant occurredAt, int attemptCount, Instant lastAttemptAt,
                              Instant dispatchedAt) {
-        this(id, eventType, schemaVersion, eventType.substring(0, eventType.indexOf('.')), aggregateType, aggregateId,
+        this(id, eventType, schemaVersion, aggregateType, aggregateId,
+            eventType.substring(0, eventType.indexOf('.')), aggregateType, aggregateId,
             payloadJson, occurredAt, attemptCount,
             lastAttemptAt, dispatchedAt, null, null, null, null);
     }


### PR DESCRIPTION
## 变更概要

- 在 Server Composition Root 中显式注册各模块 R2DBC Repository。
- 避免嵌套模块包重复扫描导致的 Repository Bean 冲突。
- Outbox 同时持久化 aggregate_type、aggregate_id 与新的 Subject Envelope 字段。
- 修正多模块运行时 classpath 下的 SQL 迁移文件匹配路径。
- 完成真实 API → Docker PostgreSQL → Console 联调。

## 验证结果

- Maven 命令：mvn -pl integration,resource,application -am test 通过。
- Maven 命令：mvn verify 通过。
- Docker PostgreSQL 18 执行 120 个迁移脚本。
- 注册、登录、JWT 鉴权、Resource 创建、列表查询和幂等重放通过。
- Console 资源管理页成功显示持久化 Resource。
- PostgreSQL 中 resource=1、event_outbox=1、migrations=120。

## 已知限制

当前开发 classpath 下多个同名 db/migration 目录需要临时聚合；生产打包时仍需补充资源聚合配置。

关闭 #903