### PR TITLE
docs(console): align canonical workspace naming with Dashboard

### DIFF
--- a/docs/00-product-baseline/Document-Index.md
+++ b/docs/00-product-baseline/Document-Index.md
@@ -72,7 +72,7 @@ Personal Drive 独立交互规格：[`app-interaction/drive/personal-drive-file-
 
 Console 一级工作区固定为：
 
-- **Overview**：Attention 与正在进行的工作；
+- **Dashboard**：Attention 与正在进行的工作；
 - **Library**：统一 Resource 浏览、搜索和 canonical Resource Detail；
 - **Add Content**：来源、预览、确认和导入；
 - **Activity**：所有长期后台工作；

--- a/docs/01-platform-foundation/cms-console-interaction/Console-Information-Architecture-and-Product-Journey-Contract.md
+++ b/docs/01-platform-foundation/cms-console-interaction/Console-Information-Architecture-and-Product-Journey-Contract.md
@@ -14,7 +14,7 @@ Console 面向用户任务，而不是后端模块。后端继续保持 Resource
 
 | 入口 | Canonical route | 职责 |
 |---|---|---|
-| Overview | `/overview` | Attention、异常和正在进行的工作 |
+| Dashboard | `/dashboard` | Attention、异常和正在进行的工作 |
 | Library | `/library` | 内容浏览、搜索和 Resource 管理 |
 | Add Content | `/add` | 上传、扫描、识别、确认导入 |
 | Activity | `/activity` | 所有长期后台工作 |
@@ -29,7 +29,7 @@ Profile、Preferences 和当前账号 Security 从头像菜单进入。
 ## 3. Canonical route tree
 
 ```text
-/overview
+/dashboard
 /library
 /library/:resourceId
 /library/collections
@@ -72,9 +72,9 @@ Profile、Preferences 和当前账号 Security 从头像菜单进入。
 
 当前设计不定义旧 route alias、redirect 或兼容页。实现发现历史 route 时直接收敛到以上最终结构。未来若进入稳定版本后需要兼容，另行建立版本化迁移契约。
 
-## 4. Overview
+## 4. Dashboard
 
-Overview 必须 Attention-first，而不是 KPI-first。优先展示：导入失败、内容不可用、Storage Provider 异常、元数据冲突、备份或同步失败、需要人工动作的后台工作。
+Dashboard 必须 Attention-first，而不是 KPI-first。优先展示：导入失败、内容不可用、Storage Provider 异常、元数据冲突、备份或同步失败、需要人工动作的后台工作。
 
 Unknown、未探测、请求失败或数据缺失不得显示为 Healthy。每条 Attention 优先进入最接近业务对象的详情页。
 
@@ -150,6 +150,7 @@ A/B/C/R 等能力 Issue 负责领域能力，不负责自行扩张全局 IA。�
 ## 13. 完成标准
 
 - Sidebar 固定为七个一级工作区；
+- Dashboard 是默认入口并承担 Attention-first 总览；
 - Library 是内容主入口；
 - Resource Detail 是内容调查起点；
 - Add Content 不暴露 Ingestion 状态机；

--- a/docs/01-platform-foundation/cms-console-interaction/Console-Product-Journey-Acceptance-Contract.md
+++ b/docs/01-platform-foundation/cms-console-interaction/Console-Product-Journey-Acceptance-Contract.md
@@ -24,7 +24,7 @@ Task Attempt、Worker、Lease、Blob Placement 等实现对象只能在必要的
 
 ## 3. GP01 首次配置并导入内容
 
-路径：`Overview → Storage/Providers → Add Content → Preview → Confirm → Activity → Library`
+路径：`Dashboard → Storage/Providers → Add Content → Preview → Confirm → Activity → Library`
 
 - [ ] 没有可用存储后端时明确说明阻塞原因并提供配置入口。
 - [ ] Provider 配置后执行真实健康探测；Unknown 不得显示为正常。
@@ -35,9 +35,9 @@ Task Attempt、Worker、Lease、Blob Placement 等实现对象只能在必要的
 
 ## 4. GP02 导入失败并恢复
 
-路径：`Overview Attention → Activity Detail → Retry → Library/Resource`
+路径：`Dashboard Attention → Activity Detail → Retry → Library/Resource`
 
-- [ ] 导入失败进入 Overview Attention。
+- [ ] 导入失败进入 Dashboard Attention。
 - [ ] 主文案使用业务动作和业务对象，不只显示 Task ID。
 - [ ] Activity Detail 展示错误摘要、关联对象和下一步。
 - [ ] 重试不重复创建已成功对象。
@@ -57,7 +57,7 @@ Task Attempt、Worker、Lease、Blob Placement 等实现对象只能在必要的
 
 ## 6. GP04 存储后端异常处理
 
-路径：`Overview Attention → Storage/Providers → Provider Detail → Probe/Update → Verify`
+路径：`Dashboard Attention → Storage/Providers → Provider Detail → Probe/Update → Verify`
 
 - [ ] 探测失败产生 Attention；未探测显示 Unknown。
 - [ ] Providers 页面聚焦连接、容量、健康、凭据状态和启停。
@@ -66,7 +66,7 @@ Task Attempt、Worker、Lease、Blob Placement 等实现对象只能在必要的
 
 ## 7. GP05 元数据冲突处理
 
-路径：`Overview/Resource Attention → Resource Detail/Metadata → Compare → Accept/Keep → Verify`
+路径：`Dashboard/Resource Attention → Resource Detail/Metadata → Compare → Accept/Keep → Verify`
 
 - [ ] 外部同步不静默覆盖人工确认值。
 - [ ] 冲突视图显示当前值、候选值、来源和必要时间信息。
@@ -104,7 +104,7 @@ Task Attempt、Worker、Lease、Blob Placement 等实现对象只能在必要的
 
 当前 V2 不验证旧路由兼容，而验证最终态是否彻底收敛：
 
-- [ ] Sidebar 仅有 Overview、Library、Add Content、Activity、Storage、Apps、System。
+- [ ] Sidebar 仅有 Dashboard、Library、Add Content、Activity、Storage、Apps、System。
 - [ ] Router 不再把历史 `*-center` 或旧 `/console/*` 结构作为产品路由。
 - [ ] 各设计文档使用同一 canonical route tree。
 - [ ] 各业务 App 只能从 Apps 进入；平台治理只能从 System 进入。
@@ -130,7 +130,7 @@ Task Attempt、Worker、Lease、Blob Placement 等实现对象只能在必要的
 - [ ] GP07 Storage 分层落地。
 - [ ] GP08 权限体验通过。
 - [ ] GP09 canonical IA 一致性通过。
-- [ ] Overview 不存在无真实数据支撑的 Healthy 状态。
+- [ ] Dashboard 不存在无真实数据支撑的 Healthy 状态。
 - [ ] 默认 Sidebar 不随后端子系统数量增长。
 - [ ] 核心旅程具有自动化 E2E 或可重复端到端验收脚本。
 

--- a/docs/01-platform-foundation/cms-console-interaction/Media-Delivery-Reliability-Budget-Operations-Supplement.md
+++ b/docs/01-platform-foundation/cms-console-interaction/Media-Delivery-Reliability-Budget-Operations-Supplement.md
@@ -30,7 +30,7 @@ Budget 视图展示真实流量、预算阈值、当前消耗和预测（仅在�
 
 没有配置预算时显示 Not configured，不用绿色正常状态代替。
 
-达到阈值后可以产生 Overview Attention，并链接到 Storage Maintenance 对应视图。
+达到阈值后可以产生 Dashboard Attention，并链接到 Storage Maintenance 对应视图。
 
 ## 4. Purge
 

--- a/docs/01-platform-foundation/cms-console-interaction/README.md
+++ b/docs/01-platform-foundation/cms-console-interaction/README.md
@@ -34,7 +34,7 @@ Console 使用 Material Design 3 作为设计语言。
 
 桌面端一级导航固定为：
 
-1. Overview；
+1. Dashboard；
 2. Library；
 3. Add Content；
 4. Activity；
@@ -64,7 +64,7 @@ Apps 与 System 内部可以出现二级导航，但它们属于各自工作区�
 
 ## 4. 七个核心工作区
 
-### Overview
+### Dashboard
 
 展示 Attention、异常和正在进行的工作。Unknown 不得渲染成 Healthy。
 
@@ -150,7 +150,7 @@ KPI 卡片只有在数据真实、有用户决策价值且存在明确目标页�
 - 404 用于目标不存在或策略要求隐藏存在性；
 - Unknown 与 Healthy 分离。
 
-单个 Overview Widget 失败不得导致整个页面失败，但该区域必须显示失败或未知。
+单个 Dashboard Widget 失败不得导致整个页面失败，但该区域必须显示失败或未知。
 
 ## 10. 后台工作
 
@@ -186,7 +186,7 @@ Resource ID、Attachment ID、Blob ID、Checksum、Placement、Replica、Provide
 
 ## 13. 跨工作区跳转
 
-- Overview Attention 优先进入业务对象详情；
+- Dashboard Attention 优先进入业务对象详情；
 - Library Resource 可以进入 Storage 状态摘要，但不直接修改物理 Placement；
 - Storage Maintenance 可以链接 Resource，但重新执行目标权限；
 - Apps 发起的长期工作统一进入 Activity；
@@ -204,7 +204,7 @@ Resource ID、Attachment ID、Blob ID、Checksum、Placement、Replica、Provide
 - `integration-automation/` → Apps/Automation + System/Integrations；
 - `authentication-entry/` → 登录前全局入口；
 - `user-preferences/` → 头像菜单；
-- `workbench/` → Overview 和全局搜索规则。
+- `workbench/` → Dashboard 和全局搜索规则。
 
 目录名称不等于产品导航名称。
 

--- a/docs/01-platform-foundation/cms-console-interaction/Storage-Delivery-Archive-Operations-Design.md
+++ b/docs/01-platform-foundation/cms-console-interaction/Storage-Delivery-Archive-Operations-Design.md
@@ -42,7 +42,7 @@ CDN、Purge、Failover、Origin、Budget、Provider routing 等高级分发运�
 
 ## 5. Failure / Failover
 
-Delivery Failure 优先反映到业务对象 Availability 和 Overview Attention。
+Delivery Failure 优先反映到业务对象 Availability 和 Dashboard Attention。
 
 Maintenance 页面可以展示 Provider、Route、Failover、Request ID 等技术字段。业务 Resource 页面只展示可理解的影响和下一步。
 

--- a/docs/01-platform-foundation/cms-console-interaction/Storage-Delivery-Restore-Safety-Supplement.md
+++ b/docs/01-platform-foundation/cms-console-interaction/Storage-Delivery-Restore-Safety-Supplement.md
@@ -38,7 +38,7 @@ Restore Failure 应：
 
 - 更新 Activity 为失败；
 - 在对应 Resource / Storage 业务视图产生可理解状态；
-- 必要时产生 Overview Attention；
+- 必要时产生 Dashboard Attention；
 - 提供下一步，例如 Retry、选择其他 Provider、进入 Maintenance。
 
 不得只显示内部 Task ID。

--- a/docs/01-platform-foundation/cms-console-interaction/authentication-entry/README.md
+++ b/docs/01-platform-foundation/cms-console-interaction/authentication-entry/README.md
@@ -11,7 +11,7 @@
 /recovery/**
 ```
 
-认证成功后的默认目标是用户原本请求的 canonical route；没有目标时进入 `/overview`。
+认证成功后的默认目标是用户原本请求的 canonical route；没有目标时进入 `/dashboard`。
 
 ## 2. First Setup
 
@@ -22,7 +22,7 @@
 - 创建初始管理员；
 - 必要基础配置；
 - 明确完成状态；
-- 完成后进入登录或已认证 `/overview`。
+- 完成后进入登录或已认证 `/dashboard`。
 
 初始化状态必须由后端一次性约束，不能只依赖前端隐藏入口。
 
@@ -55,7 +55,7 @@
 
 ## 8. 验收
 
-- 登录后默认进入 `/overview`；
+- 登录后默认进入 `/dashboard`；
 - 深链接恢复使用 canonical routes；
 - Setup 只在未初始化状态可用；
 - Login / Step-up / Recovery 状态语义明确；

--- a/docs/01-platform-foundation/cms-console-interaction/communications-audit/README.md
+++ b/docs/01-platform-foundation/cms-console-interaction/communications-audit/README.md
@@ -40,7 +40,7 @@ Audit Deep Link 进入目标业务对象时重新执行目标权限；`audit.rea
 
 ## 5. Delivery Failures
 
-投递失败可以产生 Overview Attention。用户看到 Channel、目标 Scope、错误摘要和下一步；内部 Attempt 信息进入 Advanced。
+投递失败可以产生 Dashboard Attention。用户看到 Channel、目标 Scope、错误摘要和下一步；内部 Attempt 信息进入 Advanced。
 
 ## 6. 验收
 

--- a/docs/01-platform-foundation/cms-console-interaction/platform-configuration/README.md
+++ b/docs/01-platform-foundation/cms-console-interaction/platform-configuration/README.md
@@ -34,7 +34,7 @@ Secret 不返回明文，保存后只展示已配置状态。
 
 ## 4. Navigation
 
-Console 一级导航由 IA 契约固定，不提供“平台菜单”页面让管理员任意编辑 Overview / Library / Add Content / Activity / Storage / Apps / System。
+Console 一级导航由 IA 契约固定，不提供“平台菜单”页面让管理员任意编辑 Dashboard / Library / Add Content / Activity / Storage / Apps / System。
 
 插件和 App 的可见性来自启用状态、Capability 和注册契约，而不是手工编辑全局菜单树。
 

--- a/docs/01-platform-foundation/cms-console-interaction/route-permission-matrix.md
+++ b/docs/01-platform-foundation/cms-console-interaction/route-permission-matrix.md
@@ -37,13 +37,13 @@
 | 个人通知 | `/account/notifications` | 头像菜单 | `account.notification.read` | `account.notification.update` |
 | 当前账号安全 | `/account/security` | 头像菜单 | `account.security.read` | `account.security.update` |
 
-## 3. Overview
+## 3. Dashboard
 
 | 页面 | Route | 最小能力 | 规则 |
 |---|---|---|---|
-| Overview | `/overview` | `dashboard.read` | Widget 只显示调用者有权看到的摘要；卡片动作重新检查目标能力 |
+| Dashboard | `/dashboard` | `dashboard.read` | Widget 只显示调用者有权看到的摘要；卡片动作重新检查目标能力 |
 
-Overview 可以聚合 Storage、Activity、Metadata、Backup、Sync 等状态，但聚合权限不授予目标对象额外读取能力。
+Dashboard 可以聚合 Storage、Activity、Metadata、Backup、Sync 等状态，但聚合权限不授予目标对象额外读取能力。
 
 ## 4. Library
 

--- a/docs/01-platform-foundation/cms-console-interaction/system-operations/README.md
+++ b/docs/01-platform-foundation/cms-console-interaction/system-operations/README.md
@@ -18,7 +18,7 @@ Unknown、未探测和请求失败不得显示为 Healthy。
 
 ### 1.1 Attention
 
-关键 Health Failure 可以进入 `/overview` Attention。Overview 跳转到 `/system/health` 或更接近业务对象的页面。
+关键 Health Failure 可以进入 `/dashboard` Attention。Dashboard 跳转到 `/system/health` 或更接近业务对象的页面。
 
 ### 1.2 Auto Refresh
 

--- a/docs/01-platform-foundation/cms-console-interaction/workbench/README.md
+++ b/docs/01-platform-foundation/cms-console-interaction/workbench/README.md
@@ -1,16 +1,16 @@
-# Overview 与全局工作台 — CMS Console 交互规格
+# Dashboard 与全局工作台 — CMS Console 交互规格
 
-> 本文只定义 Overview 和全局搜索。后台长期工作统一由 `/activity` 承载；收藏、消费进度和 Resource 业务活动回到 Library / Resource 语境，不再占用全局 Activity 路由。
+> 本文只定义 Dashboard 和全局搜索。后台长期工作统一由 `/activity` 承载；收藏、消费进度和 Resource 业务活动回到 Library / Resource 语境，不再占用全局 Activity 路由。
 
-## 1. Overview
+## 1. Dashboard
 
-**Route：** `/overview`
+**Route：** `/dashboard`
 
-Overview 是 Console 默认入口，目标是回答“现在有什么需要我处理”和“Ikaros 正在做什么”。
+Dashboard 是 Console 默认入口，目标是回答“现在有什么需要我处理”和“Ikaros 正在做什么”。
 
 ### 1.1 页面标题
 
-- H1：`Overview` / `概览`；
+- H1：`Dashboard` / `仪表盘`；
 - 副标题：当前环境和最近成功刷新时间；
 - 操作：刷新、必要时的显示偏好；
 - 不提供与核心任务无关的“为了填满页面”的 KPI。
@@ -121,9 +121,9 @@ Private Notes、Passwords、Finance、Drive 等继续遵守各自数据敏感性
 
 ## 4. 验收
 
-- Overview 无虚假 Healthy；
+- Dashboard 无虚假 Healthy；
 - Attention 能进入业务对象；
 - In Progress 与 `/activity` 状态一致；
 - Storage / Library 摘要可以直接应用目标筛选；
 - 全局搜索不越权；
-- 不再存在 `/console/dashboard` 或把 `/activity` 定义为收藏历史的设计要求。
+- 不再存在历史 `/console/dashboard` 或把 `/activity` 定义为收藏历史的设计要求。


### PR DESCRIPTION
## Summary

Align Console documentation with the current canonical implementation where the former global `Overview` workspace has been renamed to `Dashboard` and uses `/dashboard`.

### Updated

- Canonical IA: `Dashboard / Library / Add Content / Activity / Storage / Apps / System`
- Default route and authentication fallback: `/dashboard`
- Route/permission matrix and Dashboard capability documentation
- Golden Path / Product Journey references and acceptance criteria
- Dashboard Attention references across system health, notifications, restore, delivery and reliability docs
- Console document index and fixed-navigation documentation
- Workbench documentation renamed from global Overview semantics to Dashboard

### Intentionally unchanged

Local/domain uses such as `Storage Overview`, `Access Overview`, `System Overview Design`, and `Database Overview Design` remain unchanged because they are not the removed global workspace.

## Verification

- Branch created from current `main` at `56e71f5234ce3a43fff88d3c98c8bba4032893bc`
- Branch is ahead of `main` and not behind
- Documentation-only changes; no runtime code modified
